### PR TITLE
Fix bugs, security, and code quality from simplify review

### DIFF
--- a/migrate.php
+++ b/migrate.php
@@ -38,7 +38,6 @@ CREATE TABLE IF NOT EXISTS magic_links (
     token VARCHAR(64) UNIQUE NOT NULL,
     used TINYINT NOT NULL DEFAULT 0,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    INDEX idx_token (token),
     INDEX idx_email (email)
 ) ENGINE=InnoDB;
 ");

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -7,6 +7,9 @@ use PHPMailer\PHPMailer\PHPMailer;
 
 class Auth
 {
+    private ?array $cachedUser = null;
+    private bool $userFetched = false;
+
     public function __construct(private Database $db) {}
 
     public function user(): ?array
@@ -14,10 +17,19 @@ class Auth
         if (!isset($_SESSION['user_id'])) {
             return null;
         }
-        return $this->db->fetchOne(
-            'SELECT * FROM users WHERE id = :id',
-            [':id' => $_SESSION['user_id']]
-        );
+        if (!$this->userFetched) {
+            $this->cachedUser = $this->db->fetchOne(
+                'SELECT * FROM users WHERE id = :id',
+                [':id' => $_SESSION['user_id']]
+            );
+            $this->userFetched = true;
+        }
+        return $this->cachedUser;
+    }
+
+    public function userId(): ?int
+    {
+        return isset($_SESSION['user_id']) ? (int) $_SESSION['user_id'] : null;
     }
 
     public function isLoggedIn(): bool
@@ -53,7 +65,19 @@ class Auth
     public function loginUser(int $userId): void
     {
         $_SESSION['user_id'] = $userId;
+        $this->cachedUser = null;
+        $this->userFetched = false;
         session_regenerate_id(true);
+    }
+
+    public function consumeRedirect(): string
+    {
+        $redirect = $_SESSION['redirect_after_login'] ?? '/';
+        unset($_SESSION['redirect_after_login']);
+        if (!str_starts_with($redirect, '/') || str_starts_with($redirect, '//')) {
+            return '/';
+        }
+        return $redirect;
     }
 
     public function logout(): void
@@ -61,11 +85,16 @@ class Auth
         session_destroy();
     }
 
+    public static function normalizeEmail(string $email): string
+    {
+        return strtolower(trim($email));
+    }
+
     public function attemptPasswordLogin(string $email, string $password): ?array
     {
         $user = $this->db->fetchOne(
             'SELECT * FROM users WHERE email = :email',
-            [':email' => strtolower(trim($email))]
+            [':email' => self::normalizeEmail($email)]
         );
         if (!$user || !$user['password_hash']) {
             return null;
@@ -78,7 +107,7 @@ class Auth
 
     public function findOrCreateUserByEmail(string $email, string $name = ''): array
     {
-        $email = strtolower(trim($email));
+        $email = self::normalizeEmail($email);
         $user = $this->db->fetchOne(
             'SELECT * FROM users WHERE email = :email',
             [':email' => $email]
@@ -101,7 +130,7 @@ class Auth
         $token = bin2hex(random_bytes(32));
         $this->db->execute(
             'INSERT INTO magic_links (email, token) VALUES (:email, :token)',
-            [':email' => strtolower(trim($email)), ':token' => $token]
+            [':email' => self::normalizeEmail($email), ':token' => $token]
         );
         return $token;
     }

--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -32,7 +32,7 @@ class AdminController
 
         $where = match ($filter) {
             'awarded' => 'WHERE p.awarded_to IS NOT NULL',
-            'wanted' => 'WHERE p.awarded_to IS NULL AND (SELECT COUNT(*) FROM interests i2 WHERE i2.painting_id = p.id) > 0',
+            'wanted' => 'WHERE p.awarded_to IS NULL AND EXISTS (SELECT 1 FROM interests i2 WHERE i2.painting_id = p.id)',
             'all' => '',
             default => 'WHERE p.awarded_to IS NULL',
         };
@@ -188,8 +188,9 @@ class AdminController
             'interests' => $interests,
             'auth' => $this->auth,
             'success' => $_SESSION['admin_success'] ?? null,
+            'error' => $_SESSION['admin_error'] ?? null,
         ]);
-        unset($_SESSION['admin_success']);
+        unset($_SESSION['admin_success'], $_SESSION['admin_error']);
     }
 
     public function edit(string $id): void
@@ -200,7 +201,7 @@ class AdminController
         $description = trim($_POST['description'] ?? '');
 
         if ($title === '') {
-            $_SESSION['admin_success'] = 'Title cannot be empty.';
+            $_SESSION['admin_error'] = 'Title cannot be empty.';
             header('Location: /admin/painting/' . $id);
             exit;
         }
@@ -237,15 +238,12 @@ class AdminController
         $this->auth->requireAdmin();
 
         $painting = $this->db->fetchOne(
-            'SELECT * FROM paintings WHERE id = :id',
+            'SELECT filename FROM paintings WHERE id = :id',
             [':id' => (int) $id]
         );
 
         if ($painting) {
-            $filepath = dirname(__DIR__, 2) . '/public/uploads/' . $painting['filename'];
-            if (file_exists($filepath)) {
-                unlink($filepath);
-            }
+            @unlink(dirname(__DIR__, 2) . '/public/uploads/' . $painting['filename']);
             $this->db->execute('DELETE FROM paintings WHERE id = :id', [':id' => (int) $id]);
         }
 

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -43,9 +43,7 @@ class AuthController
             $user = $this->auth->attemptPasswordLogin($email, $password);
             if ($user) {
                 $this->auth->loginUser((int) $user['id']);
-                $redirect = $_SESSION['redirect_after_login'] ?? '/';
-                unset($_SESSION['redirect_after_login']);
-                header('Location: ' . $redirect);
+                header('Location: ' . $this->auth->consumeRedirect());
                 exit;
             }
             $_SESSION['auth_error'] = 'Invalid email or password.';
@@ -81,7 +79,7 @@ class AuthController
 
     public function register(): void
     {
-        $email = strtolower(trim($_POST['email'] ?? ''));
+        $email = Auth::normalizeEmail($_POST['email'] ?? '');
         $name = trim($_POST['name'] ?? '');
 
         if (!$email || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
@@ -130,9 +128,7 @@ class AuthController
             exit;
         }
 
-        $redirect = $_SESSION['redirect_after_login'] ?? '/';
-        unset($_SESSION['redirect_after_login']);
-        header('Location: ' . $redirect);
+        header('Location: ' . $this->auth->consumeRedirect());
         exit;
     }
 
@@ -167,7 +163,7 @@ class AuthController
         $hash = password_hash($password, PASSWORD_DEFAULT);
         $this->db->execute(
             'UPDATE users SET password_hash = :hash WHERE id = :id',
-            [':hash' => $hash, ':id' => $_SESSION['user_id']]
+            [':hash' => $hash, ':id' => $this->auth->userId()]
         );
 
         $_SESSION['auth_success'] = 'Password set successfully!';
@@ -204,9 +200,7 @@ class AuthController
             $user = $this->auth->findOrCreateUserByEmail($email, $name);
             $this->auth->loginUser((int) $user['id']);
 
-            $redirect = $_SESSION['redirect_after_login'] ?? '/';
-            unset($_SESSION['redirect_after_login']);
-            header('Location: ' . $redirect);
+            header('Location: ' . $this->auth->consumeRedirect());
             exit;
         } catch (\Exception $e) {
             error_log('OAuth error: ' . $e->getMessage());

--- a/src/Controllers/GalleryController.php
+++ b/src/Controllers/GalleryController.php
@@ -16,7 +16,6 @@ class GalleryController
     public function index(): void
     {
         $page = max(1, (int) ($_GET['page'] ?? 1));
-        $offset = ($page - 1) * self::PER_PAGE;
 
         $total = (int) $this->db->scalar(
             'SELECT COUNT(*) FROM paintings WHERE awarded_to IS NULL'
@@ -39,7 +38,7 @@ class GalleryController
         if ($this->auth->isLoggedIn()) {
             $rows = $this->db->fetchAll(
                 'SELECT painting_id FROM interests WHERE user_id = :uid',
-                [':uid' => $_SESSION['user_id']]
+                [':uid' => $this->auth->userId()]
             );
             foreach ($rows as $row) {
                 $userInterests[$row['painting_id']] = true;
@@ -72,7 +71,7 @@ class GalleryController
         if ($this->auth->isLoggedIn()) {
             $hasInterest = (bool) $this->db->fetchOne(
                 'SELECT 1 FROM interests WHERE painting_id = :pid AND user_id = :uid',
-                [':pid' => (int) $id, ':uid' => $_SESSION['user_id']]
+                [':pid' => (int) $id, ':uid' => $this->auth->userId()]
             );
         }
 
@@ -104,7 +103,7 @@ class GalleryController
 
         $existing = $this->db->fetchOne(
             'SELECT 1 FROM interests WHERE painting_id = :pid AND user_id = :uid',
-            [':pid' => (int) $id, ':uid' => $_SESSION['user_id']]
+            [':pid' => (int) $id, ':uid' => $this->auth->userId()]
         );
 
         $message = trim($_POST['message'] ?? '');
@@ -113,16 +112,19 @@ class GalleryController
             // Toggle off - remove interest
             $this->db->execute(
                 'DELETE FROM interests WHERE painting_id = :pid AND user_id = :uid',
-                [':pid' => (int) $id, ':uid' => $_SESSION['user_id']]
+                [':pid' => (int) $id, ':uid' => $this->auth->userId()]
             );
         } else {
             $this->db->execute(
                 'INSERT INTO interests (painting_id, user_id, message) VALUES (:pid, :uid, :msg)',
-                [':pid' => (int) $id, ':uid' => $_SESSION['user_id'], ':msg' => $message]
+                [':pid' => (int) $id, ':uid' => $this->auth->userId(), ':msg' => $message]
             );
         }
 
         $redirect = $_POST['redirect'] ?? '/painting/' . $id;
+        if (!str_starts_with($redirect, '/') || str_starts_with($redirect, '//')) {
+            $redirect = '/painting/' . $id;
+        }
         header('Location: ' . $redirect);
         exit;
     }

--- a/templates/admin/dashboard.php
+++ b/templates/admin/dashboard.php
@@ -1,16 +1,15 @@
 <?php
 use Heirloom\Template;
 
-// Build a sort URL: toggles direction if already sorting by that column
-function sortUrl(string $col, string $filter, string $currentSort, string $currentDir): string {
-    $newDir = ($currentSort === $col && $currentDir === 'DESC') ? 'asc' : 'desc';
+$sortUrl = function (string $col) use ($filter, $sort, $dir): string {
+    $newDir = ($sort === $col && $dir === 'DESC') ? 'asc' : 'desc';
     return '/admin?' . http_build_query(['filter' => $filter, 'sort' => $col, 'dir' => $newDir]);
-}
+};
 
-function sortIndicator(string $col, string $currentSort, string $currentDir): string {
-    if ($currentSort !== $col) return '';
-    return $currentDir === 'ASC' ? ' &#9650;' : ' &#9660;';
-}
+$sortIndicator = function (string $col) use ($sort, $dir): string {
+    if ($sort !== $col) return '';
+    return $dir === 'ASC' ? ' &#9650;' : ' &#9660;';
+};
 ?>
 
 <h1>Admin Dashboard</h1>
@@ -31,11 +30,11 @@ function sortIndicator(string $col, string $currentSort, string $currentDir): st
         <thead>
             <tr>
                 <th></th>
-                <th><a href="<?= sortUrl('title', $filter, $sort, $dir) ?>" class="sort-header">Title<?= sortIndicator('title', $sort, $dir) ?></a></th>
-                <th><a href="<?= sortUrl('interest_count', $filter, $sort, $dir) ?>" class="sort-header">Interested<?= sortIndicator('interest_count', $sort, $dir) ?></a></th>
-                <th><a href="<?= sortUrl('last_interest_at', $filter, $sort, $dir) ?>" class="sort-header">Last Interest<?= sortIndicator('last_interest_at', $sort, $dir) ?></a></th>
+                <th><a href="<?= $sortUrl('title', $filter, $sort, $dir) ?>" class="sort-header">Title<?= $sortIndicator('title', $sort, $dir) ?></a></th>
+                <th><a href="<?= $sortUrl('interest_count', $filter, $sort, $dir) ?>" class="sort-header">Interested<?= $sortIndicator('interest_count', $sort, $dir) ?></a></th>
+                <th><a href="<?= $sortUrl('last_interest_at', $filter, $sort, $dir) ?>" class="sort-header">Last Interest<?= $sortIndicator('last_interest_at', $sort, $dir) ?></a></th>
                 <th>Status</th>
-                <th><a href="<?= sortUrl('created_at', $filter, $sort, $dir) ?>" class="sort-header">Uploaded<?= sortIndicator('created_at', $sort, $dir) ?></a></th>
+                <th><a href="<?= $sortUrl('created_at', $filter, $sort, $dir) ?>" class="sort-header">Uploaded<?= $sortIndicator('created_at', $sort, $dir) ?></a></th>
                 <th>Actions</th>
             </tr>
         </thead>

--- a/templates/admin/manage.php
+++ b/templates/admin/manage.php
@@ -10,8 +10,12 @@
     </div>
     <div class="painting-detail-info">
 
+        <?php if (!empty($error)): ?>
+            <div class="alert alert-error"><?= Template::escape($error) ?></div>
+        <?php endif; ?>
+
         <?php if (!empty($success)): ?>
-            <div class="alert alert-success"><?= htmlspecialchars($success) ?></div>
+            <div class="alert alert-success"><?= Template::escape($success) ?></div>
         <?php endif; ?>
 
         <form method="POST" action="/admin/painting/<?= $painting['id'] ?>/edit" style="margin-bottom:1.5rem;">

--- a/templates/admin/upload.php
+++ b/templates/admin/upload.php
@@ -2,11 +2,11 @@
     <h1>Upload Paintings</h1>
 
     <?php if (!empty($error)): ?>
-        <div class="alert alert-error"><?= htmlspecialchars($error) ?></div>
+        <div class="alert alert-error"><?= \Heirloom\Template::escape($error) ?></div>
     <?php endif; ?>
 
     <?php if (!empty($success)): ?>
-        <div class="alert alert-success"><?= htmlspecialchars($success) ?></div>
+        <div class="alert alert-success"><?= \Heirloom\Template::escape($success) ?></div>
     <?php endif; ?>
 
     <div class="form-card">

--- a/templates/layout.php
+++ b/templates/layout.php
@@ -13,7 +13,7 @@
             <div class="nav-links">
                 <?php if ($auth && $auth->isLoggedIn()): ?>
                     <?php $user = $auth->user(); ?>
-                    <span class="nav-user"><?= htmlspecialchars($user['name'] ?: $user['email']) ?></span>
+                    <span class="nav-user"><?= \Heirloom\Template::escape($user['name'] ?: $user['email']) ?></span>
                     <?php if ($auth->isAdmin()): ?>
                         <a href="/admin">Admin</a>
                         <a href="/admin/upload">Upload</a>

--- a/templates/login.php
+++ b/templates/login.php
@@ -2,11 +2,11 @@
     <h1>Log In</h1>
 
     <?php if (!empty($error)): ?>
-        <div class="alert alert-error"><?= htmlspecialchars($error) ?></div>
+        <div class="alert alert-error"><?= \Heirloom\Template::escape($error) ?></div>
     <?php endif; ?>
 
     <?php if (!empty($success)): ?>
-        <div class="alert alert-success"><?= htmlspecialchars($success) ?></div>
+        <div class="alert alert-success"><?= \Heirloom\Template::escape($success) ?></div>
     <?php endif; ?>
 
     <div class="form-card">

--- a/templates/register.php
+++ b/templates/register.php
@@ -2,7 +2,7 @@
     <h1>Create Account</h1>
 
     <?php if (!empty($error)): ?>
-        <div class="alert alert-error"><?= htmlspecialchars($error) ?></div>
+        <div class="alert alert-error"><?= \Heirloom\Template::escape($error) ?></div>
     <?php endif; ?>
 
     <div class="form-card">

--- a/templates/set-password.php
+++ b/templates/set-password.php
@@ -3,11 +3,11 @@
     <p style="margin-bottom:1rem;color:var(--text-muted)">Optional: set a password so you can log in without a magic link next time.</p>
 
     <?php if (!empty($error)): ?>
-        <div class="alert alert-error"><?= htmlspecialchars($error) ?></div>
+        <div class="alert alert-error"><?= \Heirloom\Template::escape($error) ?></div>
     <?php endif; ?>
 
     <?php if (!empty($success)): ?>
-        <div class="alert alert-success"><?= htmlspecialchars($success) ?></div>
+        <div class="alert alert-success"><?= \Heirloom\Template::escape($success) ?></div>
     <?php endif; ?>
 
     <div class="form-card">

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -62,6 +62,62 @@ class AuthTest extends TestCase
         $this->assertTrue($this->auth->isLoggedIn());
     }
 
+    // --- userId ---
+
+    public function testUserIdReturnsNullWhenNotLoggedIn(): void
+    {
+        $this->assertNull($this->auth->userId());
+    }
+
+    public function testUserIdReturnsIntWhenLoggedIn(): void
+    {
+        $_SESSION['user_id'] = 42;
+        $this->assertSame(42, $this->auth->userId());
+    }
+
+    // --- normalizeEmail ---
+
+    public function testNormalizeEmailLowercasesAndTrims(): void
+    {
+        $this->assertSame('test@example.com', Auth::normalizeEmail('  TEST@EXAMPLE.COM  '));
+    }
+
+    // --- consumeRedirect ---
+
+    public function testConsumeRedirectReturnsStoredPath(): void
+    {
+        $_SESSION['redirect_after_login'] = '/painting/5';
+        $this->assertSame('/painting/5', $this->auth->consumeRedirect());
+        $this->assertArrayNotHasKey('redirect_after_login', $_SESSION);
+    }
+
+    public function testConsumeRedirectDefaultsToSlash(): void
+    {
+        $this->assertSame('/', $this->auth->consumeRedirect());
+    }
+
+    public function testConsumeRedirectRejectsExternalUrl(): void
+    {
+        $_SESSION['redirect_after_login'] = '//evil.com/steal';
+        $this->assertSame('/', $this->auth->consumeRedirect());
+    }
+
+    // --- user caching ---
+
+    public function testUserResultIsCached(): void
+    {
+        $this->db->execute(
+            "INSERT INTO users (email, name, is_admin) VALUES (:e, :n, 0)",
+            [':e' => 'cached@example.com', ':n' => 'Cached']
+        );
+        $id = $this->db->lastInsertId();
+        $_SESSION['user_id'] = $id;
+
+        $user1 = $this->auth->user();
+        $user2 = $this->auth->user();
+        $this->assertSame($user1, $user2);
+    }
+
     // --- user ---
 
     public function testUserReturnsNullWhenNotLoggedIn(): void


### PR DESCRIPTION
## Summary
- **Bug fix:** `admin_success` session key was storing error messages — split into `admin_error`/`admin_success` with correct alert styling
- **Security:** Close open redirect vulnerabilities in `expressInterest()` and `consumeRedirect()`, standardize all HTML escaping to `Template::escape()`
- **Performance:** Cache `Auth::user()` per-request (eliminates 2-3 duplicate DB queries per page), use `EXISTS` over `COUNT(*)`, `SELECT filename` over `SELECT *`, remove redundant index
- **Code quality:** Extract `Auth::userId()`, `Auth::normalizeEmail()`, `Auth::consumeRedirect()` to reduce duplication and encapsulate session access; closures replace global functions in dashboard template

## Test plan
- [ ] 59 tests pass (7 new: userId, normalizeEmail, consumeRedirect, user caching, open redirect rejection)
- [ ] Login as admin, edit a painting with empty title — should show red error alert, not green success
- [ ] Express interest via form with tampered redirect field — should not redirect to external URL
- [ ] Admin dashboard "Wanted" filter still works correctly
- [ ] Verify page loads don't duplicate user queries (check PHP dev server logs)