### PR TITLE
Add required PHP extensions and license to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,13 @@
     "name": "sartin/heirloom",
     "description": "Painting giveaway gallery",
     "type": "project",
+    "license": "Apache-2.0",
     "require": {
         "php": ">=8.1",
+        "ext-pdo": "*",
+        "ext-pdo_mysql": "*",
+        "ext-fileinfo": "*",
+        "ext-mbstring": "*",
         "league/oauth2-client": "^2.7",
         "league/oauth2-google": "^4.0",
         "phpmailer/phpmailer": "^6.9"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77fdd8580d715838bd6508d55c24c16a",
+    "content-hash": "49132cf936ce984f3643b02a99c602b7",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -4160,7 +4160,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1"
+        "php": ">=8.1",
+        "ext-pdo": "*",
+        "ext-pdo_mysql": "*",
+        "ext-fileinfo": "*",
+        "ext-mbstring": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"


### PR DESCRIPTION
## Summary
- Declare `ext-pdo`, `ext-pdo_mysql`, `ext-fileinfo`, `ext-mbstring` as requirements
- Add `"license": "Apache-2.0"` to match the LICENSE file
- `composer validate` now passes cleanly

## Test plan
- [ ] `composer validate` returns clean
- [ ] `composer install` still succeeds
- [ ] All 59 tests pass