### PR TITLE
Add CI, CODEOWNERS, and automated PR review

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           tools: composer
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: composer update --no-interaction --prefer-dist
 
       - name: Run PHPUnit
         run: vendor/bin/phpunit


### PR DESCRIPTION
## Summary
- **GitHub Actions CI** (`.github/workflows/tests.yml`): runs PHPUnit and PHPSpec on PHP 8.3 for all PRs and pushes to main
- **CODEOWNERS** (`.github/CODEOWNERS`): `@robsartin` owns all files — external PRs require maintainer approval
- **Automated PR review** (`.github/workflows/pr-review.yml`): Claude Sonnet reviews PRs from external contributors, posts APPROVE or REQUEST_CHANGES
- **Branch protection** configured on `main`: required status checks, required reviews, dismiss stale reviews

## Setup required after merge
- Add `ANTHROPIC_API_KEY` repo secret: `gh secret set ANTHROPIC_API_KEY --repo robsartin/heirloom`

## Test plan
- [x] CI workflow passes (PHPUnit + PHPSpec)
- [ ] Verify CODEOWNERS takes effect on next external PR
- [ ] Verify PR review bot runs after ANTHROPIC_API_KEY secret is set