### PR TITLE
Restrict Google OAuth to existing users, register via magic link only

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -105,6 +105,14 @@ class Auth
         return $user;
     }
 
+    public function findUserByEmail(string $email): ?array
+    {
+        return $this->db->fetchOne(
+            'SELECT * FROM users WHERE email = :email',
+            [':email' => self::normalizeEmail($email)]
+        );
+    }
+
     public function findOrCreateUserByEmail(string $email, string $name = ''): array
     {
         $email = self::normalizeEmail($email);

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -195,11 +195,15 @@ class AuthController
             $token = $provider->getAccessToken('authorization_code', ['code' => $_GET['code']]);
             $googleUser = $provider->getResourceOwner($token);
             $email = strtolower($googleUser->getEmail());
-            $name = $googleUser->getName() ?? '';
 
-            $user = $this->auth->findOrCreateUserByEmail($email, $name);
+            $user = $this->auth->findUserByEmail($email);
+            if (!$user) {
+                $_SESSION['auth_error'] = 'No account found for that Google email. Please register first.';
+                header('Location: /register');
+                exit;
+            }
+
             $this->auth->loginUser((int) $user['id']);
-
             header('Location: ' . $this->auth->consumeRedirect());
             exit;
         } catch (\Exception $e) {

--- a/templates/register.php
+++ b/templates/register.php
@@ -5,11 +5,9 @@
         <div class="alert alert-error"><?= \Heirloom\Template::escape($error) ?></div>
     <?php endif; ?>
 
+    <p style="margin-bottom:1rem;color:var(--text-muted)">Enter your name and email to receive a login link.</p>
+
     <div class="form-card">
-        <a href="/auth/google" class="btn btn-google">Sign up with Google</a>
-
-        <div class="divider">or use email</div>
-
         <form method="POST" action="/register">
             <div class="form-group">
                 <label for="name">Your Name</label>

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -170,6 +170,36 @@ class AuthTest extends TestCase
         $this->assertFalse($this->auth->isAdmin());
     }
 
+    // --- findUserByEmail ---
+
+    public function testFindUserByEmailReturnsUserWhenExists(): void
+    {
+        $this->db->execute(
+            "INSERT INTO users (email, name) VALUES (:e, :n)",
+            [':e' => 'found@example.com', ':n' => 'Found']
+        );
+
+        $user = $this->auth->findUserByEmail('found@example.com');
+        $this->assertNotNull($user);
+        $this->assertSame('found@example.com', $user['email']);
+    }
+
+    public function testFindUserByEmailReturnsNullWhenNotExists(): void
+    {
+        $this->assertNull($this->auth->findUserByEmail('ghost@example.com'));
+    }
+
+    public function testFindUserByEmailNormalizesEmail(): void
+    {
+        $this->db->execute(
+            "INSERT INTO users (email, name) VALUES (:e, :n)",
+            [':e' => 'normalize@example.com', ':n' => 'Norm']
+        );
+
+        $user = $this->auth->findUserByEmail('  NORMALIZE@EXAMPLE.COM  ');
+        $this->assertNotNull($user);
+    }
+
     // --- attemptPasswordLogin ---
 
     public function testAttemptPasswordLoginSucceedsWithCorrectCredentials(): void


### PR DESCRIPTION
## Summary
- Google OAuth2 login now **rejects** users who don't already have an account — redirects to /register with "No account found" error
- Registration page **only** offers magic link (email + name form) — Google button removed
- Login page keeps Google button (for existing users who want one-click login)
- Added `Auth::findUserByEmail()` — lookup without auto-creation
- 3 new tests (74 total, up from 71)

## How account creation now works
1. User goes to /register, enters name + email
2. Magic link sent to their email
3. Clicking the link creates the account and logs them in
4. After that, they can log in via password, magic link, or Google OAuth

## Test plan
- [ ] 74 tests pass
- [ ] Register page has no Google button
- [ ] Google login with unknown email redirects to /register with error
- [ ] Google login with known email works normally
- [ ] Magic link registration still creates accounts