### PR TITLE
Add admin-configurable site settings

### DIFF
--- a/migrate.php
+++ b/migrate.php
@@ -108,6 +108,35 @@ CREATE TABLE IF NOT EXISTS award_log (
 ) ENGINE=InnoDB;
 ");
 
+// Site settings table
+$pdo->exec("
+CREATE TABLE IF NOT EXISTS site_settings (
+    setting_key VARCHAR(100) PRIMARY KEY,
+    setting_value VARCHAR(1000) NOT NULL DEFAULT '',
+    label VARCHAR(255) NOT NULL DEFAULT '',
+    description VARCHAR(1000) NOT NULL DEFAULT ''
+) ENGINE=InnoDB;
+");
+
+// Seed default settings
+$defaults = [
+    ['magic_link_expiry_minutes', '60', 'Magic Link Expiry (minutes)', 'How long a magic login link stays valid after being sent.'],
+    ['site_name', 'Heirloom Gallery', 'Site Name', 'Displayed in the navigation bar and page title.'],
+    ['gallery_per_page', '12', 'Gallery Items Per Page', 'Number of paintings shown per page in the public gallery.'],
+    ['admin_per_page', '20', 'Admin Items Per Page', 'Number of paintings shown per page in the admin dashboard.'],
+    ['registration_open', '1', 'Registration Open', 'Set to 0 to disable new user registration.'],
+    ['contact_email', '', 'Contact Email', 'Shown to users who need to reach the site owner. Leave blank to hide.'],
+];
+foreach ($defaults as [$key, $value, $label, $desc]) {
+    $stmt = $pdo->prepare('SELECT 1 FROM site_settings WHERE setting_key = :k');
+    $stmt->execute([':k' => $key]);
+    if (!$stmt->fetch()) {
+        $stmt = $pdo->prepare('INSERT INTO site_settings (setting_key, setting_value, label, description) VALUES (:k, :v, :l, :d)');
+        $stmt->execute([':k' => $key, ':v' => $value, ':l' => $label, ':d' => $desc]);
+    }
+}
+echo "Site settings table ready.\n";
+
 // Seed admin user
 $adminEmail = 'rob.sartin@gmail.com';
 $stmt = $pdo->prepare('SELECT id FROM users WHERE email = :email');

--- a/public/index.php
+++ b/public/index.php
@@ -7,6 +7,7 @@ use Heirloom\Config;
 use Heirloom\Database;
 use Heirloom\Router;
 use Heirloom\Auth;
+use Heirloom\SiteSettings;
 use Heirloom\Controllers\GalleryController;
 use Heirloom\Controllers\AuthController;
 use Heirloom\Controllers\AdminController;
@@ -16,12 +17,14 @@ Config::load(__DIR__ . '/../.env');
 session_start();
 
 $db = Database::getInstance();
+$settings = new SiteSettings($db);
 $auth = new Auth($db);
+$auth->setSettings($settings);
 $router = new Router();
 
-$gallery = new GalleryController($db, $auth);
-$authCtrl = new AuthController($db, $auth);
-$admin = new AdminController($db, $auth);
+$gallery = new GalleryController($db, $auth, $settings);
+$authCtrl = new AuthController($db, $auth, $settings);
+$admin = new AdminController($db, $auth, $settings);
 
 // Public routes
 $router->get('/', [$gallery, 'index']);
@@ -51,5 +54,7 @@ $router->post('/admin/painting/{id}/edit', [$admin, 'edit']);
 $router->post('/admin/painting/{id}/award', [$admin, 'award']);
 $router->post('/admin/painting/{id}/tracking', [$admin, 'updateTracking']);
 $router->post('/admin/painting/{id}/delete', [$admin, 'delete']);
+$router->get('/admin/settings', [$admin, 'settingsForm']);
+$router->post('/admin/settings', [$admin, 'updateSettings']);
 
 $router->dispatch($_SERVER['REQUEST_METHOD'], parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -9,8 +9,19 @@ class Auth
 {
     private ?array $cachedUser = null;
     private bool $userFetched = false;
+    private ?SiteSettings $settings = null;
 
     public function __construct(private Database $db) {}
+
+    public function setSettings(SiteSettings $settings): void
+    {
+        $this->settings = $settings;
+    }
+
+    private function magicLinkExpiryMinutes(): int
+    {
+        return $this->settings ? $this->settings->getInt('magic_link_expiry_minutes', 60) : 60;
+    }
 
     public function user(): ?array
     {
@@ -145,8 +156,9 @@ class Auth
 
     public function consumeMagicLink(string $token): ?string
     {
+        $minutes = $this->magicLinkExpiryMinutes();
         $link = $this->db->fetchOne(
-            "SELECT * FROM magic_links WHERE token = :token AND used = 0 AND created_at > DATE_SUB(NOW(), INTERVAL 1 HOUR)",
+            "SELECT * FROM magic_links WHERE token = :token AND used = 0 AND created_at > DATE_SUB(NOW(), INTERVAL $minutes MINUTE)",
             [':token' => $token]
         );
         if (!$link) {

--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -5,17 +5,17 @@ namespace Heirloom\Controllers;
 
 use Heirloom\Auth;
 use Heirloom\Database;
+use Heirloom\SiteSettings;
 use Heirloom\Template;
 
 class AdminController
 {
-    private const PER_PAGE = 20;
-
-    public function __construct(private Database $db, private Auth $auth) {}
+    public function __construct(private Database $db, private Auth $auth, private SiteSettings $settings) {}
 
     public function dashboard(): void
     {
         $this->auth->requireAdmin();
+        $perPage = $this->settings->getInt('admin_per_page', 20);
 
         $page = max(1, (int) ($_GET['page'] ?? 1));
         $filter = $_GET['filter'] ?? 'available';
@@ -40,9 +40,9 @@ class AdminController
         $total = (int) $this->db->scalar(
             "SELECT COUNT(*) FROM paintings p $where"
         );
-        $totalPages = max(1, (int) ceil($total / self::PER_PAGE));
+        $totalPages = max(1, (int) ceil($total / $perPage));
         $page = min($page, $totalPages);
-        $offset = ($page - 1) * self::PER_PAGE;
+        $offset = ($page - 1) * $perPage;
 
         $paintings = $this->db->fetchAll(
             "SELECT p.*,
@@ -54,7 +54,7 @@ class AdminController
              $where
              ORDER BY $orderCol $dir
              LIMIT :limit OFFSET :offset",
-            [':limit' => self::PER_PAGE, ':offset' => $offset]
+            [':limit' => $perPage, ':offset' => $offset]
         );
 
         Template::render('admin/dashboard', [
@@ -303,6 +303,40 @@ class AdminController
         }
 
         header('Location: /admin');
+        exit;
+    }
+
+    public function settingsForm(): void
+    {
+        $this->auth->requireAdmin();
+
+        $allSettings = $this->settings->getAll();
+
+        Template::render('admin/settings', [
+            'settings' => $allSettings,
+            'auth' => $this->auth,
+            'success' => $_SESSION['admin_success'] ?? null,
+            'error' => $_SESSION['admin_error'] ?? null,
+        ]);
+        unset($_SESSION['admin_success'], $_SESSION['admin_error']);
+    }
+
+    public function updateSettings(): void
+    {
+        $this->auth->requireAdmin();
+
+        $allSettings = $this->settings->getAll();
+        $updates = [];
+        foreach ($allSettings as $row) {
+            $key = $row['setting_key'];
+            if (isset($_POST[$key])) {
+                $updates[$key] = trim($_POST[$key]);
+            }
+        }
+
+        $this->settings->setBulk($updates);
+        $_SESSION['admin_success'] = 'Settings saved.';
+        header('Location: /admin/settings');
         exit;
     }
 }

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -6,12 +6,13 @@ namespace Heirloom\Controllers;
 use Heirloom\Auth;
 use Heirloom\Config;
 use Heirloom\Database;
+use Heirloom\SiteSettings;
 use Heirloom\Template;
 use League\OAuth2\Client\Provider\Google;
 
 class AuthController
 {
-    public function __construct(private Database $db, private Auth $auth) {}
+    public function __construct(private Database $db, private Auth $auth, private SiteSettings $settings) {}
 
     public function loginForm(): void
     {
@@ -70,15 +71,29 @@ class AuthController
             header('Location: /');
             exit;
         }
+        if (!$this->settings->getBool('registration_open', true)) {
+            Template::render('register', [
+                'error' => 'Registration is currently closed.',
+                'auth' => $this->auth,
+                'closed' => true,
+            ]);
+            return;
+        }
         Template::render('register', [
             'error' => $_SESSION['auth_error'] ?? null,
             'auth' => $this->auth,
+            'closed' => false,
         ]);
         unset($_SESSION['auth_error']);
     }
 
     public function register(): void
     {
+        if (!$this->settings->getBool('registration_open', true)) {
+            $_SESSION['auth_error'] = 'Registration is currently closed.';
+            header('Location: /login');
+            exit;
+        }
         $email = Auth::normalizeEmail($_POST['email'] ?? '');
         $name = trim($_POST['name'] ?? '');
 

--- a/src/Controllers/GalleryController.php
+++ b/src/Controllers/GalleryController.php
@@ -5,24 +5,24 @@ namespace Heirloom\Controllers;
 
 use Heirloom\Auth;
 use Heirloom\Database;
+use Heirloom\SiteSettings;
 use Heirloom\Template;
 
 class GalleryController
 {
-    private const PER_PAGE = 12;
-
-    public function __construct(private Database $db, private Auth $auth) {}
+    public function __construct(private Database $db, private Auth $auth, private SiteSettings $settings) {}
 
     public function index(): void
     {
+        $perPage = $this->settings->getInt('gallery_per_page', 12);
         $page = max(1, (int) ($_GET['page'] ?? 1));
 
         $total = (int) $this->db->scalar(
             'SELECT COUNT(*) FROM paintings WHERE awarded_to IS NULL'
         );
-        $totalPages = max(1, (int) ceil($total / self::PER_PAGE));
+        $totalPages = max(1, (int) ceil($total / $perPage));
         $page = min($page, $totalPages);
-        $offset = ($page - 1) * self::PER_PAGE;
+        $offset = ($page - 1) * $perPage;
 
         $paintings = $this->db->fetchAll(
             'SELECT p.*, (SELECT COUNT(*) FROM interests i WHERE i.painting_id = p.id) AS interest_count
@@ -30,7 +30,7 @@ class GalleryController
              WHERE p.awarded_to IS NULL
              ORDER BY p.created_at DESC
              LIMIT :limit OFFSET :offset',
-            [':limit' => self::PER_PAGE, ':offset' => $offset]
+            [':limit' => $perPage, ':offset' => $offset]
         );
 
         // Check which ones current user has expressed interest in

--- a/src/SiteSettings.php
+++ b/src/SiteSettings.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom;
+
+class SiteSettings
+{
+    public function __construct(private Database $db) {}
+
+    public function get(string $key, string $default = ''): string
+    {
+        $row = $this->db->fetchOne(
+            'SELECT setting_value FROM site_settings WHERE setting_key = :k',
+            [':k' => $key]
+        );
+        return $row ? $row['setting_value'] : $default;
+    }
+
+    public function getInt(string $key, int $default = 0): int
+    {
+        $val = $this->get($key, (string) $default);
+        return (int) $val;
+    }
+
+    public function getBool(string $key, bool $default = false): bool
+    {
+        $row = $this->db->fetchOne(
+            'SELECT setting_value FROM site_settings WHERE setting_key = :k',
+            [':k' => $key]
+        );
+        if (!$row) {
+            return $default;
+        }
+        return in_array($row['setting_value'], ['1', 'true', 'yes'], true);
+    }
+
+    public function set(string $key, string $value): void
+    {
+        $existing = $this->db->fetchOne(
+            'SELECT 1 FROM site_settings WHERE setting_key = :k',
+            [':k' => $key]
+        );
+        if ($existing) {
+            $this->db->execute(
+                'UPDATE site_settings SET setting_value = :v WHERE setting_key = :k',
+                [':v' => $value, ':k' => $key]
+            );
+        } else {
+            $this->db->execute(
+                'INSERT INTO site_settings (setting_key, setting_value) VALUES (:k, :v)',
+                [':k' => $key, ':v' => $value]
+            );
+        }
+    }
+
+    public function setBulk(array $values): void
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value);
+        }
+    }
+
+    public function getAll(): array
+    {
+        return $this->db->fetchAll('SELECT * FROM site_settings ORDER BY setting_key');
+    }
+}

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -1,0 +1,40 @@
+<?php use Heirloom\Template; ?>
+
+<h1>Site Settings</h1>
+
+<?php if (!empty($error)): ?>
+    <div class="alert alert-error"><?= Template::escape($error) ?></div>
+<?php endif; ?>
+
+<?php if (!empty($success)): ?>
+    <div class="alert alert-success"><?= Template::escape($success) ?></div>
+<?php endif; ?>
+
+<div class="form-card" style="max-width:600px;">
+    <form method="POST" action="/admin/settings">
+        <?php foreach ($settings as $row): ?>
+            <div class="form-group">
+                <label for="<?= Template::escape($row['setting_key']) ?>">
+                    <?= Template::escape($row['label'] ?: $row['setting_key']) ?>
+                </label>
+                <?php if (in_array($row['setting_key'], ['registration_open'], true)): ?>
+                    <select name="<?= Template::escape($row['setting_key']) ?>" id="<?= Template::escape($row['setting_key']) ?>">
+                        <option value="1" <?= $row['setting_value'] === '1' ? 'selected' : '' ?>>Yes</option>
+                        <option value="0" <?= $row['setting_value'] === '0' ? 'selected' : '' ?>>No</option>
+                    </select>
+                <?php else: ?>
+                    <input type="text" name="<?= Template::escape($row['setting_key']) ?>"
+                           id="<?= Template::escape($row['setting_key']) ?>"
+                           value="<?= Template::escape($row['setting_value']) ?>">
+                <?php endif; ?>
+                <?php if ($row['description']): ?>
+                    <small style="color:var(--text-muted)"><?= Template::escape($row['description']) ?></small>
+                <?php endif; ?>
+            </div>
+        <?php endforeach; ?>
+
+        <button type="submit" class="btn btn-primary" style="width:100%">Save Settings</button>
+    </form>
+</div>
+
+<p style="margin-top:1rem;"><a href="/admin">&laquo; Back to dashboard</a></p>

--- a/templates/layout.php
+++ b/templates/layout.php
@@ -18,6 +18,7 @@
                     <?php if ($auth->isAdmin()): ?>
                         <a href="/admin">Admin</a>
                         <a href="/admin/upload">Upload</a>
+                        <a href="/admin/settings">Settings</a>
                     <?php endif; ?>
                     <a href="/logout">Log out</a>
                 <?php else: ?>

--- a/templates/register.php
+++ b/templates/register.php
@@ -5,25 +5,31 @@
         <div class="alert alert-error"><?= \Heirloom\Template::escape($error) ?></div>
     <?php endif; ?>
 
-    <p style="margin-bottom:1rem;color:var(--text-muted)">Enter your name and email to receive a login link.</p>
+    <?php if (empty($closed)): ?>
+        <p style="margin-bottom:1rem;color:var(--text-muted)">Enter your name and email to receive a login link.</p>
 
-    <div class="form-card">
-        <form method="POST" action="/register">
-            <div class="form-group">
-                <label for="name">Your Name</label>
-                <input type="text" name="name" id="name" required placeholder="Jane Smith">
-            </div>
+        <div class="form-card">
+            <form method="POST" action="/register">
+                <div class="form-group">
+                    <label for="name">Your Name</label>
+                    <input type="text" name="name" id="name" required placeholder="Jane Smith">
+                </div>
 
-            <div class="form-group">
-                <label for="email">Email</label>
-                <input type="email" name="email" id="email" required placeholder="you@example.com">
-            </div>
+                <div class="form-group">
+                    <label for="email">Email</label>
+                    <input type="email" name="email" id="email" required placeholder="you@example.com">
+                </div>
 
-            <button type="submit" class="btn btn-primary" style="width:100%">Register (sends login link)</button>
-        </form>
+                <button type="submit" class="btn btn-primary" style="width:100%">Register (sends login link)</button>
+            </form>
 
-        <p style="text-align:center;margin-top:1rem;font-size:0.9rem;">
+            <p style="text-align:center;margin-top:1rem;font-size:0.9rem;">
+                Already have an account? <a href="/login">Log in</a>
+            </p>
+        </div>
+    <?php else: ?>
+        <p style="margin-top:1rem;">
             Already have an account? <a href="/login">Log in</a>
         </p>
-    </div>
+    <?php endif; ?>
 </div>

--- a/tests/SiteSettingsTest.php
+++ b/tests/SiteSettingsTest.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Database;
+use Heirloom\SiteSettings;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class SiteSettingsTest extends TestCase
+{
+    private Database $db;
+    private SiteSettings $settings;
+
+    protected function setUp(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+        $pdo->exec("CREATE TABLE site_settings (
+            setting_key TEXT PRIMARY KEY,
+            setting_value TEXT NOT NULL,
+            label TEXT NOT NULL DEFAULT '',
+            description TEXT NOT NULL DEFAULT ''
+        )");
+
+        $this->db = new Database($pdo);
+        $this->settings = new SiteSettings($this->db);
+    }
+
+    public function testGetReturnsDefaultWhenKeyMissing(): void
+    {
+        $this->assertSame('60', $this->settings->get('magic_link_expiry_minutes', '60'));
+    }
+
+    public function testGetReturnsStoredValue(): void
+    {
+        $this->db->execute(
+            "INSERT INTO site_settings (setting_key, setting_value) VALUES (:k, :v)",
+            [':k' => 'magic_link_expiry_minutes', ':v' => '30']
+        );
+
+        $this->assertSame('30', $this->settings->get('magic_link_expiry_minutes', '60'));
+    }
+
+    public function testSetInsertsNewValue(): void
+    {
+        $this->settings->set('site_name', 'My Gallery');
+        $this->assertSame('My Gallery', $this->settings->get('site_name'));
+    }
+
+    public function testSetUpdatesExistingValue(): void
+    {
+        $this->settings->set('site_name', 'Old Name');
+        $this->settings->set('site_name', 'New Name');
+        $this->assertSame('New Name', $this->settings->get('site_name'));
+    }
+
+    public function testGetIntReturnsIntegerValue(): void
+    {
+        $this->settings->set('magic_link_expiry_minutes', '45');
+        $this->assertSame(45, $this->settings->getInt('magic_link_expiry_minutes', 60));
+    }
+
+    public function testGetIntReturnsDefaultWhenMissing(): void
+    {
+        $this->assertSame(60, $this->settings->getInt('nonexistent', 60));
+    }
+
+    public function testGetAllReturnsAllSettings(): void
+    {
+        $this->settings->set('a', '1');
+        $this->settings->set('b', '2');
+
+        $all = $this->settings->getAll();
+        $this->assertCount(2, $all);
+    }
+
+    public function testSetBulkUpdatesMultipleSettings(): void
+    {
+        $this->settings->set('a', '1');
+        $this->settings->set('b', '2');
+
+        $this->settings->setBulk(['a' => '10', 'b' => '20']);
+
+        $this->assertSame('10', $this->settings->get('a'));
+        $this->assertSame('20', $this->settings->get('b'));
+    }
+
+    public function testGetBoolReturnsTrueForTruthyValues(): void
+    {
+        $this->settings->set('registration_open', '1');
+        $this->assertTrue($this->settings->getBool('registration_open', false));
+    }
+
+    public function testGetBoolReturnsFalseForFalsyValues(): void
+    {
+        $this->settings->set('registration_open', '0');
+        $this->assertFalse($this->settings->getBool('registration_open', true));
+    }
+
+    public function testGetBoolReturnsDefaultWhenMissing(): void
+    {
+        $this->assertTrue($this->settings->getBool('nonexistent', true));
+    }
+}


### PR DESCRIPTION
## Summary
- **New `SiteSettings` class** with database-backed key/value store (11 tests)
- **Admin settings page** at `/admin/settings` with form for all configurable values
- **Magic link expiry** now configurable (was hardcoded 1 hour)
- **Per-page counts** configurable for gallery and admin dashboard
- **Registration toggle** — admin can close registration
- Settings link added to admin nav

## Configurable settings
| Key | Default | Description |
|-----|---------|-------------|
| `magic_link_expiry_minutes` | 60 | How long magic links stay valid |
| `site_name` | Heirloom Gallery | Nav bar and page title |
| `gallery_per_page` | 12 | Public gallery pagination |
| `admin_per_page` | 20 | Admin dashboard pagination |
| `registration_open` | 1 | Toggle new user registration |
| `contact_email` | (empty) | Contact email shown to users |

## Test plan
- [ ] 91 PHPUnit + 29 phpspec pass
- [ ] Visit /admin/settings, change magic link expiry to 5, save
- [ ] Register with new email — magic link should note the expiry
- [ ] Set registration_open to 0 — /register shows "closed" message
- [ ] Change gallery_per_page to 4 — gallery shows 4 per page