### PR TITLE
Improve admin settings page layout and styling

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -260,6 +260,8 @@ main {
 .form-group input[type="text"],
 .form-group input[type="email"],
 .form-group input[type="password"],
+.form-group input[type="number"],
+.form-group select,
 .form-group textarea {
     width: 100%;
     padding: 0.5rem;
@@ -453,6 +455,74 @@ main {
     padding: 0.15rem 0.5rem;
     border-radius: 3px;
     font-size: 0.8rem;
+}
+
+/* Settings */
+.settings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1.5rem;
+}
+
+.settings-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.25rem;
+}
+
+.settings-card-title {
+    font-size: 1.1rem;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--accent);
+}
+
+.settings-field {
+    margin-bottom: 1.25rem;
+}
+
+.settings-field:last-child {
+    margin-bottom: 0;
+}
+
+.settings-field label {
+    display: block;
+    font-size: 0.9rem;
+    font-weight: bold;
+    margin-bottom: 0.3rem;
+}
+
+.settings-field input[type="text"],
+.settings-field input[type="number"] {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 0.95rem;
+    font-family: inherit;
+}
+
+.settings-input-short {
+    max-width: 120px;
+}
+
+.settings-field select {
+    padding: 0.45rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 0.95rem;
+    font-family: inherit;
+    background: var(--surface);
+    cursor: pointer;
+}
+
+.settings-desc {
+    margin-top: 0.25rem;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    line-height: 1.4;
 }
 
 /* Footer */

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -1,6 +1,9 @@
 <?php use Heirloom\Template; ?>
 
+<div style="margin-bottom:1rem;"><a href="/admin">&laquo; Back to dashboard</a></div>
+
 <h1>Site Settings</h1>
+<p style="color:var(--text-muted);margin-bottom:1.5rem;">Configure how Heirloom Gallery behaves. Changes take effect immediately.</p>
 
 <?php if (!empty($error)): ?>
     <div class="alert alert-error"><?= Template::escape($error) ?></div>
@@ -10,31 +13,59 @@
     <div class="alert alert-success"><?= Template::escape($success) ?></div>
 <?php endif; ?>
 
-<div class="form-card" style="max-width:600px;">
-    <form method="POST" action="/admin/settings">
-        <?php foreach ($settings as $row): ?>
-            <div class="form-group">
-                <label for="<?= Template::escape($row['setting_key']) ?>">
-                    <?= Template::escape($row['label'] ?: $row['setting_key']) ?>
-                </label>
-                <?php if (in_array($row['setting_key'], ['registration_open'], true)): ?>
-                    <select name="<?= Template::escape($row['setting_key']) ?>" id="<?= Template::escape($row['setting_key']) ?>">
-                        <option value="1" <?= $row['setting_value'] === '1' ? 'selected' : '' ?>>Yes</option>
-                        <option value="0" <?= $row['setting_value'] === '0' ? 'selected' : '' ?>>No</option>
-                    </select>
-                <?php else: ?>
-                    <input type="text" name="<?= Template::escape($row['setting_key']) ?>"
-                           id="<?= Template::escape($row['setting_key']) ?>"
-                           value="<?= Template::escape($row['setting_value']) ?>">
-                <?php endif; ?>
-                <?php if ($row['description']): ?>
-                    <small style="color:var(--text-muted)"><?= Template::escape($row['description']) ?></small>
-                <?php endif; ?>
+<?php
+$groups = [
+    'General' => ['site_name', 'contact_email'],
+    'Authentication' => ['magic_link_expiry_minutes', 'registration_open'],
+    'Display' => ['gallery_per_page', 'admin_per_page'],
+];
+$numeric = ['magic_link_expiry_minutes', 'gallery_per_page', 'admin_per_page'];
+$boolean = ['registration_open'];
+$keyed = [];
+foreach ($settings as $row) {
+    $keyed[$row['setting_key']] = $row;
+}
+?>
+
+<form method="POST" action="/admin/settings">
+    <div class="settings-grid">
+        <?php foreach ($groups as $groupName => $keys): ?>
+            <div class="settings-card">
+                <h2 class="settings-card-title"><?= Template::escape($groupName) ?></h2>
+                <?php foreach ($keys as $key): ?>
+                    <?php if (!isset($keyed[$key])) continue; ?>
+                    <?php $row = $keyed[$key]; ?>
+                    <div class="settings-field">
+                        <div class="settings-field-header">
+                            <label for="<?= Template::escape($key) ?>"><?= Template::escape($row['label'] ?: $key) ?></label>
+                        </div>
+                        <?php if (in_array($key, $boolean, true)): ?>
+                            <div class="settings-toggle">
+                                <select name="<?= Template::escape($key) ?>" id="<?= Template::escape($key) ?>">
+                                    <option value="1" <?= $row['setting_value'] === '1' ? 'selected' : '' ?>>Yes</option>
+                                    <option value="0" <?= $row['setting_value'] === '0' ? 'selected' : '' ?>>No</option>
+                                </select>
+                            </div>
+                        <?php elseif (in_array($key, $numeric, true)): ?>
+                            <input type="number" name="<?= Template::escape($key) ?>"
+                                   id="<?= Template::escape($key) ?>"
+                                   value="<?= Template::escape($row['setting_value']) ?>"
+                                   min="1" class="settings-input-short">
+                        <?php else: ?>
+                            <input type="text" name="<?= Template::escape($key) ?>"
+                                   id="<?= Template::escape($key) ?>"
+                                   value="<?= Template::escape($row['setting_value']) ?>">
+                        <?php endif; ?>
+                        <?php if ($row['description']): ?>
+                            <p class="settings-desc"><?= Template::escape($row['description']) ?></p>
+                        <?php endif; ?>
+                    </div>
+                <?php endforeach; ?>
             </div>
         <?php endforeach; ?>
+    </div>
 
-        <button type="submit" class="btn btn-primary" style="width:100%">Save Settings</button>
-    </form>
-</div>
-
-<p style="margin-top:1rem;"><a href="/admin">&laquo; Back to dashboard</a></p>
+    <div style="margin-top:1.5rem;">
+        <button type="submit" class="btn btn-primary">Save All Settings</button>
+    </div>
+</form>


### PR DESCRIPTION
## Summary
- Settings organized into grouped cards: **General**, **Authentication**, **Display**
- Responsive grid layout — cards flow into columns on wide screens, stack on narrow
- Number inputs with `min=1` for numeric settings (expiry, per-page counts)
- Styled select dropdowns for boolean settings (Yes/No)
- Muted description text below each field
- Back-to-dashboard link and intro text

## Test plan
- [ ] All tests pass
- [ ] Visit /admin/settings — settings grouped into 3 cards
- [ ] Resize browser — cards stack vertically on narrow screens
- [ ] Number fields only accept numbers, min 1
- [ ] Save works correctly