### PR TITLE
Display contact_email setting in site footer

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -22,6 +22,7 @@ session_start();
 $db = Database::getInstance();
 $settings = new SiteSettings($db);
 Template::setGlobal('siteName', $settings->get('site_name', SiteSettings::DEFAULT_SITE_NAME));
+Template::setGlobal('contactEmail', $settings->get('contact_email', ''));
 $auth = new Auth($db);
 $auth->setSettings($settings);
 $mailHost = Config::get('MAIL_HOST');

--- a/templates/layout.php
+++ b/templates/layout.php
@@ -34,6 +34,9 @@
     <footer class="footer">
         <div class="container">
             <p><?= \Heirloom\Template::escape($siteName) ?> &mdash; Paintings looking for new homes</p>
+            <?php if (!empty($contactEmail)): ?>
+                <p>Contact: <a href="mailto:<?= \Heirloom\Template::escape($contactEmail) ?>"><?= \Heirloom\Template::escape($contactEmail) ?></a></p>
+            <?php endif; ?>
         </div>
     </footer>
 </body>

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -83,6 +83,111 @@ class TemplateTest extends TestCase
         $this->assertSame('Hello World!', $output);
     }
 
+    public function testSetGlobalMakesValueAvailableInTemplate(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/heirloom_tpl_' . uniqid();
+        mkdir($tmpDir);
+        file_put_contents($tmpDir . '/global_test.php', 'Email: <?= $contactEmail ?>');
+        file_put_contents($tmpDir . '/layout.php', '<?= $content ?>');
+
+        $ref = new \ReflectionClass(Template::class);
+        $baseProp = $ref->getProperty('baseDir');
+        $globalsProp = $ref->getProperty('globals');
+
+        $originalBase = $baseProp->getValue();
+        $originalGlobals = $globalsProp->getValue();
+
+        $baseProp->setValue(null, $tmpDir);
+        Template::setGlobal('contactEmail', 'gallery@example.com');
+
+        ob_start();
+        Template::render('global_test', ['noLayout' => true]);
+        $output = ob_get_clean();
+
+        $baseProp->setValue(null, $originalBase);
+        $globalsProp->setValue(null, $originalGlobals);
+
+        unlink($tmpDir . '/global_test.php');
+        unlink($tmpDir . '/layout.php');
+        rmdir($tmpDir);
+
+        $this->assertSame('Email: gallery@example.com', $output);
+    }
+
+    public function testContactEmailRenderedInLayoutFooter(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/heirloom_tpl_' . uniqid();
+        mkdir($tmpDir);
+        file_put_contents($tmpDir . '/blank.php', '');
+
+        // Create a minimal layout that mirrors the real footer contact email logic
+        $layoutContent = <<<'PHP'
+<?= $content ?><?php if (!empty($contactEmail)): ?><a href="mailto:<?= \Heirloom\Template::escape($contactEmail) ?>"><?= \Heirloom\Template::escape($contactEmail) ?></a><?php endif; ?>
+PHP;
+        file_put_contents($tmpDir . '/layout.php', $layoutContent);
+
+        $ref = new \ReflectionClass(Template::class);
+        $baseProp = $ref->getProperty('baseDir');
+        $globalsProp = $ref->getProperty('globals');
+
+        $originalBase = $baseProp->getValue();
+        $originalGlobals = $globalsProp->getValue();
+
+        $baseProp->setValue(null, $tmpDir);
+        Template::setGlobal('contactEmail', 'art@example.com');
+        Template::setGlobal('siteName', 'Test Gallery');
+
+        ob_start();
+        Template::render('blank', []);
+        $output = ob_get_clean();
+
+        $baseProp->setValue(null, $originalBase);
+        $globalsProp->setValue(null, $originalGlobals);
+
+        unlink($tmpDir . '/blank.php');
+        unlink($tmpDir . '/layout.php');
+        rmdir($tmpDir);
+
+        $this->assertStringContainsString('mailto:art@example.com', $output);
+        $this->assertStringContainsString('>art@example.com</a>', $output);
+    }
+
+    public function testContactEmailHiddenWhenEmpty(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/heirloom_tpl_' . uniqid();
+        mkdir($tmpDir);
+        file_put_contents($tmpDir . '/blank.php', '');
+
+        $layoutContent = <<<'PHP'
+<?= $content ?><?php if (!empty($contactEmail)): ?><a href="mailto:<?= \Heirloom\Template::escape($contactEmail) ?>"><?= \Heirloom\Template::escape($contactEmail) ?></a><?php endif; ?>
+PHP;
+        file_put_contents($tmpDir . '/layout.php', $layoutContent);
+
+        $ref = new \ReflectionClass(Template::class);
+        $baseProp = $ref->getProperty('baseDir');
+        $globalsProp = $ref->getProperty('globals');
+
+        $originalBase = $baseProp->getValue();
+        $originalGlobals = $globalsProp->getValue();
+
+        $baseProp->setValue(null, $tmpDir);
+        Template::setGlobal('contactEmail', '');
+        Template::setGlobal('siteName', 'Test Gallery');
+
+        ob_start();
+        Template::render('blank', []);
+        $output = ob_get_clean();
+
+        $baseProp->setValue(null, $originalBase);
+        $globalsProp->setValue(null, $originalGlobals);
+
+        unlink($tmpDir . '/blank.php');
+        unlink($tmpDir . '/layout.php');
+        rmdir($tmpDir);
+
+        $this->assertStringNotContainsString('mailto:', $output);
+    }
+
     public function testRenderWithLayoutWrapsContent(): void
     {
         $tmpDir = sys_get_temp_dir() . '/heirloom_tpl_' . uniqid();


### PR DESCRIPTION
## Summary
- Pass `contact_email` site setting as a global template variable via `Template::setGlobal()` in `public/index.php`
- Render it as a `mailto:` link in the layout footer, hidden when empty
- Add three PHPUnit tests: global variable propagation, footer link rendering, and empty-email hidden state

Closes #25

## Test plan
- [x] `composer check` passes (110 tests, 29 specs)
- [ ] Verify contact email appears in footer when `contact_email` is set in admin settings
- [ ] Verify no contact link shown when `contact_email` is empty/unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)