### PR TITLE
Add CSRF protection to all forms (closes #19)

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use Heirloom\Config;
+use Heirloom\Csrf;
 use Heirloom\Database;
 use Heirloom\Router;
 use Heirloom\Auth;
@@ -73,5 +74,15 @@ $router->post('/admin/painting/{id}/tracking', [$admin, 'updateTracking']);
 $router->post('/admin/painting/{id}/delete', [$admin, 'delete']);
 $router->get('/admin/settings', [$admin, 'settingsForm']);
 $router->post('/admin/settings', [$admin, 'updateSettings']);
+
+// CSRF validation for all POST requests
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $token = $_POST['_csrf_token'] ?? '';
+    if (!Csrf::validate($token)) {
+        http_response_code(403);
+        echo '<h1>403 Forbidden</h1><p>Invalid or missing CSRF token. Please go back and try again.</p>';
+        exit;
+    }
+}
 
 $router->dispatch($_SERVER['REQUEST_METHOD'], parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));

--- a/src/Csrf.php
+++ b/src/Csrf.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom;
+
+class Csrf
+{
+    public static function generateToken(): string
+    {
+        if (!isset($_SESSION['csrf_token'])) {
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+        }
+        return $_SESSION['csrf_token'];
+    }
+
+    public static function validate(string $token): bool
+    {
+        if (!isset($_SESSION['csrf_token']) || $token === '') {
+            return false;
+        }
+        return hash_equals($_SESSION['csrf_token'], $token);
+    }
+
+    public static function hiddenField(): string
+    {
+        $token = self::generateToken();
+        return '<input type="hidden" name="_csrf_token" value="' . Template::escape($token) . '">';
+    }
+}

--- a/templates/admin/manage.php
+++ b/templates/admin/manage.php
@@ -19,6 +19,7 @@
         <?php endif; ?>
 
         <form method="POST" action="/admin/painting/<?= $painting['id'] ?>/edit" style="margin-bottom:1.5rem;">
+            <?= \Heirloom\Csrf::hiddenField() ?>
             <div class="form-group">
                 <label for="title">Title</label>
                 <input type="text" name="title" id="title" required
@@ -56,6 +57,7 @@
                 <?php endif; ?>
 
                 <form method="POST" action="/admin/painting/<?= $painting['id'] ?>/tracking" style="margin-top:0.75rem;">
+            <?= \Heirloom\Csrf::hiddenField() ?>
                     <div class="form-group" style="margin-bottom:0.5rem;">
                         <label for="tracking_number" style="font-size:0.85rem;">Tracking Number</label>
                         <input type="text" name="tracking_number" id="tracking_number"
@@ -66,6 +68,7 @@
                 </form>
 
                 <form method="POST" action="/admin/painting/<?= $painting['id'] ?>/award" style="margin-top:0.75rem;">
+            <?= \Heirloom\Csrf::hiddenField() ?>
                     <input type="hidden" name="user_id" value="">
                     <button type="submit" class="btn btn-sm btn-danger"
                             onclick="return confirm('Unassign this painting? This clears tracking info too.')">
@@ -97,6 +100,7 @@
                         </div>
                         <?php if (!$painting['awarded_to']): ?>
                             <form method="POST" action="/admin/painting/<?= $painting['id'] ?>/award">
+            <?= \Heirloom\Csrf::hiddenField() ?>
                                 <input type="hidden" name="user_id" value="<?= $interest['user_id'] ?>">
                                 <button type="submit" class="btn btn-sm btn-success"
                                         onclick="return confirm('Award this painting to <?= Template::escape($interest['name'] ?: $interest['email']) ?>?')">
@@ -136,6 +140,7 @@
         <form method="POST" action="/admin/painting/<?= $painting['id'] ?>/delete"
               style="margin-top:2rem;"
               onsubmit="return confirm('Delete this painting permanently?')">
+            <?= \Heirloom\Csrf::hiddenField() ?>
             <button type="submit" class="btn btn-danger btn-sm">Delete Painting</button>
         </form>
     </div>

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -28,6 +28,7 @@ foreach ($settings as $row) {
 ?>
 
 <form method="POST" action="/admin/settings">
+            <?= \Heirloom\Csrf::hiddenField() ?>
     <div class="settings-grid">
         <?php foreach ($groups as $groupName => $keys): ?>
             <div class="settings-card">

--- a/templates/admin/upload.php
+++ b/templates/admin/upload.php
@@ -11,6 +11,7 @@
 
     <div class="form-card">
         <form method="POST" action="/admin/upload" enctype="multipart/form-data">
+            <?= \Heirloom\Csrf::hiddenField() ?>
             <div class="form-group">
                 <label for="title">Title</label>
                 <input type="text" name="title" id="title" placeholder="Painting title">

--- a/templates/login.php
+++ b/templates/login.php
@@ -15,6 +15,7 @@
         <div class="divider">or use email</div>
 
         <form method="POST" action="/login">
+            <?= \Heirloom\Csrf::hiddenField() ?>
             <div class="form-group">
                 <label for="email">Email</label>
                 <input type="email" name="email" id="email" required placeholder="you@example.com">

--- a/templates/painting.php
+++ b/templates/painting.php
@@ -19,6 +19,7 @@
             <p><span class="awarded-label">This painting has been claimed</span></p>
         <?php elseif ($auth->isLoggedIn()): ?>
             <form method="POST" action="/painting/<?= $painting['id'] ?>/interest">
+            <?= \Heirloom\Csrf::hiddenField() ?>
                 <?php if (!$hasInterest): ?>
                     <div class="form-group">
                         <label for="message">Why do you want this painting? (optional)</label>

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -14,6 +14,7 @@
         <p style="margin-bottom:1rem;color:var(--text-muted);font-size:0.9rem;"><?= \Heirloom\Template::escape($user['email']) ?></p>
 
         <form method="POST" action="/profile">
+            <?= \Heirloom\Csrf::hiddenField() ?>
             <div class="form-group">
                 <label for="shipping_address">Shipping Address</label>
                 <textarea name="shipping_address" id="shipping_address" rows="4"

--- a/templates/register.php
+++ b/templates/register.php
@@ -10,6 +10,7 @@
 
         <div class="form-card">
             <form method="POST" action="/register">
+            <?= \Heirloom\Csrf::hiddenField() ?>
                 <div class="form-group">
                     <label for="name">Your Name</label>
                     <input type="text" name="name" id="name" required placeholder="Jane Smith">

--- a/templates/set-password.php
+++ b/templates/set-password.php
@@ -12,6 +12,7 @@
 
     <div class="form-card">
         <form method="POST" action="/set-password">
+            <?= \Heirloom\Csrf::hiddenField() ?>
             <div class="form-group">
                 <label for="password">New Password (min 8 characters)</label>
                 <input type="password" name="password" id="password" required minlength="8">

--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Csrf;
+use PHPUnit\Framework\TestCase;
+
+class CsrfTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!isset($_SESSION)) {
+            $_SESSION = [];
+        }
+        unset($_SESSION['csrf_token']);
+    }
+
+    public function testGenerateTokenReturnsString(): void
+    {
+        $token = Csrf::generateToken();
+        $this->assertIsString($token);
+        $this->assertNotEmpty($token);
+    }
+
+    public function testGenerateTokenIs64HexChars(): void
+    {
+        $token = Csrf::generateToken();
+        $this->assertSame(64, strlen($token));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $token);
+    }
+
+    public function testGenerateTokenStoresInSession(): void
+    {
+        $token = Csrf::generateToken();
+        $this->assertSame($token, $_SESSION['csrf_token']);
+    }
+
+    public function testGenerateTokenReturnsSameTokenIfAlreadySet(): void
+    {
+        $token1 = Csrf::generateToken();
+        $token2 = Csrf::generateToken();
+        $this->assertSame($token1, $token2);
+    }
+
+    public function testValidateReturnsTrueForCorrectToken(): void
+    {
+        $token = Csrf::generateToken();
+        $this->assertTrue(Csrf::validate($token));
+    }
+
+    public function testValidateReturnsFalseForWrongToken(): void
+    {
+        Csrf::generateToken();
+        $this->assertFalse(Csrf::validate('wrong-token'));
+    }
+
+    public function testValidateReturnsFalseForEmptyToken(): void
+    {
+        Csrf::generateToken();
+        $this->assertFalse(Csrf::validate(''));
+    }
+
+    public function testValidateReturnsFalseWhenNoSessionToken(): void
+    {
+        $this->assertFalse(Csrf::validate('anything'));
+    }
+
+    public function testHiddenFieldReturnsHtmlInput(): void
+    {
+        $token = Csrf::generateToken();
+        $html = Csrf::hiddenField();
+        $this->assertStringContainsString('type="hidden"', $html);
+        $this->assertStringContainsString('name="_csrf_token"', $html);
+        $this->assertStringContainsString("value=\"$token\"", $html);
+    }
+}


### PR DESCRIPTION
## Summary
- New `Csrf` class with `generateToken()`, `validate()`, `hiddenField()` (9 tests)
- All 12 POST forms across 8 templates include CSRF hidden field
- Front controller validates CSRF token on every POST, rejects with 403 on mismatch
- Uses `hash_equals()` for timing-safe comparison

Closes #19

## Test plan
- [ ] 116 PHPUnit + 29 phpspec pass
- [ ] Submit a form normally — works
- [ ] Tamper with or remove `_csrf_token` from a POST — get 403
- [ ] CSRF token persists across requests within same session