### PR TITLE
Send email notification when a painting is awarded

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -210,4 +210,32 @@ HTML;
             return false;
         }
     }
+
+    public function buildAwardEmail(string $recipientEmail, string $paintingTitle): EmailMessage
+    {
+        $name = $this->siteName();
+
+        $subject = "A painting has been awarded to you - $name";
+        $htmlBody = <<<HTML
+<h2>Congratulations!</h2>
+<p>You have been awarded the painting <strong>$paintingTitle</strong> from $name.</p>
+<p>We will be in touch with shipping details soon.</p>
+HTML;
+        $textBody = "Congratulations! You have been awarded the painting \"$paintingTitle\" from $name. We will be in touch with shipping details soon.";
+
+        return new EmailMessage($recipientEmail, $subject, $htmlBody, $textBody);
+    }
+
+    public function sendAwardNotification(string $email, string $paintingTitle): bool
+    {
+        $message = $this->buildAwardEmail($email, $paintingTitle);
+        $mailer = $this->mailer ?? new LogMailer();
+
+        try {
+            return $mailer->send($message);
+        } catch (\Exception $e) {
+            error_log("Mail error: " . $e->getMessage());
+            return false;
+        }
+    }
 }

--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -253,6 +253,19 @@ class AdminController
                 'INSERT INTO award_log (painting_id, user_id, awarded_by, action) VALUES (:pid, :uid, :aid, :action)',
                 [':pid' => (int) $id, ':uid' => $userId, ':aid' => $adminId, ':action' => 'awarded']
             );
+
+            $recipient = $this->db->fetchOne(
+                'SELECT email FROM users WHERE id = :id',
+                [':id' => $userId]
+            );
+            $painting = $this->db->fetchOne(
+                'SELECT title FROM paintings WHERE id = :id',
+                [':id' => (int) $id]
+            );
+            if ($recipient && $painting) {
+                $this->auth->sendAwardNotification($recipient['email'], $painting['title']);
+            }
+
             $_SESSION['admin_success'] = 'Painting awarded!';
         } else {
             $painting = $this->db->fetchOne('SELECT awarded_to FROM paintings WHERE id = :id', [':id' => (int) $id]);

--- a/tests/AwardNotificationTest.php
+++ b/tests/AwardNotificationTest.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Auth;
+use Heirloom\Database;
+use Heirloom\LogMailer;
+use Heirloom\SiteSettings;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class AwardNotificationTest extends TestCase
+{
+    private Auth $auth;
+    private Database $db;
+    private LogMailer $mailer;
+    private SiteSettings $settings;
+
+    protected function setUp(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        $pdo->exec("CREATE TABLE users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email TEXT UNIQUE NOT NULL,
+            name TEXT NOT NULL DEFAULT '',
+            password_hash TEXT,
+            is_admin INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )");
+        $pdo->exec("CREATE TABLE site_settings (
+            setting_key TEXT PRIMARY KEY,
+            setting_value TEXT NOT NULL DEFAULT '',
+            label TEXT NOT NULL DEFAULT '',
+            description TEXT NOT NULL DEFAULT ''
+        )");
+
+        $this->db = new Database($pdo);
+        $this->settings = new SiteSettings($this->db);
+        $this->mailer = new LogMailer();
+        $this->auth = new Auth($this->db);
+        $this->auth->setSettings($this->settings);
+        $this->auth->setMailer($this->mailer);
+    }
+
+    public function testBuildAwardEmailReturnsEmailMessageWithCorrectRecipient(): void
+    {
+        $msg = $this->auth->buildAwardEmail('alice@example.com', 'Sunset over the Lake');
+        $this->assertSame('alice@example.com', $msg->to);
+    }
+
+    public function testBuildAwardEmailSubjectContainsSiteName(): void
+    {
+        $this->settings->set('site_name', 'Art Giveaway');
+        $msg = $this->auth->buildAwardEmail('bob@example.com', 'Mountain Vista');
+        $this->assertStringContainsString('Art Giveaway', $msg->subject);
+    }
+
+    public function testBuildAwardEmailSubjectUsesDefaultSiteNameWhenNotConfigured(): void
+    {
+        $msg = $this->auth->buildAwardEmail('carol@example.com', 'Mountain Vista');
+        $this->assertStringContainsString('Heirloom Gallery', $msg->subject);
+    }
+
+    public function testBuildAwardEmailBodyContainsPaintingTitle(): void
+    {
+        $msg = $this->auth->buildAwardEmail('dan@example.com', 'Sunset over the Lake');
+        $this->assertStringContainsString('Sunset over the Lake', $msg->htmlBody);
+    }
+
+    public function testBuildAwardEmailTextBodyContainsPaintingTitle(): void
+    {
+        $msg = $this->auth->buildAwardEmail('eve@example.com', 'Sunset over the Lake');
+        $this->assertStringContainsString('Sunset over the Lake', $msg->textBody);
+    }
+
+    public function testSendAwardNotificationSendsEmailViaMailer(): void
+    {
+        $result = $this->auth->sendAwardNotification('frank@example.com', 'Autumn Leaves');
+        $this->assertTrue($result);
+
+        $msg = $this->mailer->getLastMessage();
+        $this->assertNotNull($msg);
+        $this->assertSame('frank@example.com', $msg->to);
+        $this->assertStringContainsString('Autumn Leaves', $msg->htmlBody);
+    }
+
+    public function testSendAwardNotificationUsesDefaultMailerWhenNoneSet(): void
+    {
+        $auth = new Auth($this->db);
+        $auth->setSettings($this->settings);
+        // No mailer set — should fall back to LogMailer without error
+        $result = $auth->sendAwardNotification('grace@example.com', 'Spring Blossoms');
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `buildAwardEmail()` and `sendAwardNotification()` methods to `Auth`, following the existing `buildMagicLinkEmail`/`sendMagicLink` pattern
- Call `sendAwardNotification()` in `AdminController::award()` after a painting is awarded to a user
- Add `AwardNotificationTest` with 7 tests covering email recipient, subject with site name, body with painting title, and mailer integration

## Test plan
- [x] `composer check` passes (129 PHPUnit tests + 29 phpspec examples, all green)
- [ ] Manually award a painting in admin and verify recipient receives notification email

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)