### PR TITLE
Add rate limiting on login and registration (closes #21)

### DIFF
--- a/migrate.php
+++ b/migrate.php
@@ -108,6 +108,16 @@ CREATE TABLE IF NOT EXISTS award_log (
 ) ENGINE=InnoDB;
 ");
 
+// Login attempts table (rate limiting)
+$pdo->exec("
+CREATE TABLE IF NOT EXISTS login_attempts (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    identifier VARCHAR(255) NOT NULL,
+    attempted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_identifier_time (identifier, attempted_at)
+) ENGINE=InnoDB;
+");
+
 // Site settings table
 $pdo->exec("
 CREATE TABLE IF NOT EXISTS site_settings (

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -6,13 +6,19 @@ namespace Heirloom\Controllers;
 use Heirloom\Auth;
 use Heirloom\Config;
 use Heirloom\Database;
+use Heirloom\RateLimiter;
 use Heirloom\SiteSettings;
 use Heirloom\Template;
 use League\OAuth2\Client\Provider\Google;
 
 class AuthController
 {
-    public function __construct(private Database $db, private Auth $auth, private SiteSettings $settings) {}
+    private RateLimiter $rateLimiter;
+
+    public function __construct(private Database $db, private Auth $auth, private SiteSettings $settings)
+    {
+        $this->rateLimiter = new RateLimiter($db);
+    }
 
     public function loginForm(): void
     {
@@ -39,20 +45,29 @@ class AuthController
             exit;
         }
 
-        // If password provided, attempt password login
+        $identifier = Auth::normalizeEmail($email);
+        if (!$this->rateLimiter->isAllowed($identifier)) {
+            $remaining = $this->rateLimiter->remainingAttempts($identifier);
+            $_SESSION['auth_error'] = 'Too many login attempts. Please try again in 15 minutes.';
+            header('Location: /login');
+            exit;
+        }
+
         if ($password !== '') {
             $user = $this->auth->attemptPasswordLogin($email, $password);
             if ($user) {
+                $this->rateLimiter->clear($identifier);
                 $this->auth->loginUser((int) $user['id']);
                 header('Location: ' . $this->auth->consumeRedirect());
                 exit;
             }
+            $this->rateLimiter->record($identifier);
             $_SESSION['auth_error'] = 'Invalid email or password.';
             header('Location: /login');
             exit;
         }
 
-        // No password = send magic link
+        $this->rateLimiter->record($identifier);
         $token = $this->auth->createMagicLink($email);
         $sent = $this->auth->sendMagicLink($email, $token);
 
@@ -103,16 +118,21 @@ class AuthController
             exit;
         }
 
+        if (!$this->rateLimiter->isAllowed($email)) {
+            $_SESSION['auth_error'] = 'Too many attempts. Please try again in 15 minutes.';
+            header('Location: /register');
+            exit;
+        }
+
         if (!$name) {
             $_SESSION['auth_error'] = 'Name is required.';
             header('Location: /register');
             exit;
         }
 
-        // Create user if not exists
         $this->auth->findOrCreateUserByEmail($email, $name);
+        $this->rateLimiter->record($email);
 
-        // Send magic link
         $token = $this->auth->createMagicLink($email);
         $sent = $this->auth->sendMagicLink($email, $token);
 

--- a/src/RateLimiter.php
+++ b/src/RateLimiter.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom;
+
+class RateLimiter
+{
+    public function __construct(
+        private Database $db,
+        private int $maxAttempts = 5,
+        private int $windowMinutes = 15,
+    ) {}
+
+    public function isAllowed(string $identifier): bool
+    {
+        return $this->getAttemptCount($identifier) < $this->maxAttempts;
+    }
+
+    public function record(string $identifier): void
+    {
+        $this->db->execute(
+            'INSERT INTO login_attempts (identifier) VALUES (:id)',
+            [':id' => $identifier]
+        );
+    }
+
+    public function getAttemptCount(string $identifier): int
+    {
+        $cutoff = date('Y-m-d H:i:s', time() - ($this->windowMinutes * 60));
+        return (int) $this->db->scalar(
+            "SELECT COUNT(*) FROM login_attempts WHERE identifier = :id AND attempted_at > :cutoff",
+            [':id' => $identifier, ':cutoff' => $cutoff]
+        );
+    }
+
+    public function remainingAttempts(string $identifier): int
+    {
+        return max(0, $this->maxAttempts - $this->getAttemptCount($identifier));
+    }
+
+    public function clear(string $identifier): void
+    {
+        $this->db->execute(
+            'DELETE FROM login_attempts WHERE identifier = :id',
+            [':id' => $identifier]
+        );
+    }
+}

--- a/tests/RateLimiterTest.php
+++ b/tests/RateLimiterTest.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Database;
+use Heirloom\RateLimiter;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class RateLimiterTest extends TestCase
+{
+    private Database $db;
+    private RateLimiter $limiter;
+
+    protected function setUp(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+        $pdo->exec("CREATE TABLE login_attempts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            identifier TEXT NOT NULL,
+            attempted_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )");
+
+        $this->db = new Database($pdo);
+        $this->limiter = new RateLimiter($this->db, maxAttempts: 5, windowMinutes: 15);
+    }
+
+    public function testIsAllowedReturnsTrueWithNoAttempts(): void
+    {
+        $this->assertTrue($this->limiter->isAllowed('test@example.com'));
+    }
+
+    public function testIsAllowedReturnsTrueUnderLimit(): void
+    {
+        for ($i = 0; $i < 4; $i++) {
+            $this->limiter->record('test@example.com');
+        }
+        $this->assertTrue($this->limiter->isAllowed('test@example.com'));
+    }
+
+    public function testIsAllowedReturnsFalseAtLimit(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->limiter->record('test@example.com');
+        }
+        $this->assertFalse($this->limiter->isAllowed('test@example.com'));
+    }
+
+    public function testIsAllowedReturnsFalseOverLimit(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->limiter->record('test@example.com');
+        }
+        $this->assertFalse($this->limiter->isAllowed('test@example.com'));
+    }
+
+    public function testDifferentIdentifiersAreIndependent(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->limiter->record('blocked@example.com');
+        }
+        $this->assertFalse($this->limiter->isAllowed('blocked@example.com'));
+        $this->assertTrue($this->limiter->isAllowed('free@example.com'));
+    }
+
+    public function testRecordIncreasesCount(): void
+    {
+        $this->assertSame(0, $this->limiter->getAttemptCount('test@example.com'));
+        $this->limiter->record('test@example.com');
+        $this->assertSame(1, $this->limiter->getAttemptCount('test@example.com'));
+    }
+
+    public function testRemainingAttemptsDecreasesCorrectly(): void
+    {
+        $this->assertSame(5, $this->limiter->remainingAttempts('test@example.com'));
+        $this->limiter->record('test@example.com');
+        $this->assertSame(4, $this->limiter->remainingAttempts('test@example.com'));
+    }
+
+    public function testRemainingAttemptsNeverGoesNegative(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->limiter->record('test@example.com');
+        }
+        $this->assertSame(0, $this->limiter->remainingAttempts('test@example.com'));
+    }
+
+    public function testClearRemovesAttempts(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->limiter->record('test@example.com');
+        }
+        $this->assertFalse($this->limiter->isAllowed('test@example.com'));
+
+        $this->limiter->clear('test@example.com');
+        $this->assertTrue($this->limiter->isAllowed('test@example.com'));
+    }
+}


### PR DESCRIPTION
## Summary
- New `RateLimiter` class: 5 attempts per 15 minutes per email (9 tests)
- Login endpoint: checks limit before attempt, records failures, clears on success
- Register endpoint: checks limit before processing, records each attempt
- Magic link requests count toward the limit (prevents email spam)
- `login_attempts` table with composite index

Closes #21

## Test plan
- [ ] 131 PHPUnit + 29 phpspec pass
- [ ] Login with wrong password 5 times — 6th attempt blocked with "Too many attempts"
- [ ] Successful login clears the counter
- [ ] Register 5 times — 6th attempt blocked