### PR TITLE
Make admin dashboard table mobile-responsive

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -535,6 +535,12 @@ main {
     margin-top: 2rem;
 }
 
+/* Admin table scroll wrapper */
+.admin-table-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .gallery-grid {
@@ -549,5 +555,13 @@ main {
     .nav-container {
         flex-direction: column;
         gap: 0.5rem;
+    }
+
+    .filter-bar {
+        flex-wrap: wrap;
+    }
+
+    .admin-table {
+        min-width: 700px;
     }
 }

--- a/templates/admin/dashboard.php
+++ b/templates/admin/dashboard.php
@@ -26,6 +26,7 @@ $sortIndicator = function (string $col) use ($sort, $dir): string {
 <?php if (empty($paintings)): ?>
     <p>No paintings found.</p>
 <?php else: ?>
+    <div class="admin-table-wrap">
     <table class="admin-table">
         <thead>
             <tr>
@@ -60,6 +61,7 @@ $sortIndicator = function (string $col) use ($sort, $dir): string {
             <?php endforeach; ?>
         </tbody>
     </table>
+    </div>
 
     <?php if ($totalPages > 1): ?>
         <?php $qs = http_build_query(['filter' => $filter, 'sort' => $sort, 'dir' => strtolower($dir)]); ?>


### PR DESCRIPTION
## Summary
- Wrapped the admin dashboard table in a `.admin-table-wrap` div with `overflow-x: auto` so it scrolls horizontally on narrow screens instead of overlapping
- Added `flex-wrap: wrap` to the `.filter-bar` so filter links wrap properly on mobile
- Set `min-width: 700px` on the table inside the 768px breakpoint to ensure columns stay readable when scrolling

Closes #23

## Test plan
- [ ] Open `/admin` on a phone or at <768px width — table should scroll horizontally, no column overlap
- [ ] Filter bar buttons should wrap onto a second row on narrow screens
- [ ] Desktop layout should be unchanged
- [ ] Verify `composer check` passes (143 tests, 29 specs)

Generated with [Claude Code](https://claude.com/claude-code)