### PR TITLE
Generate image thumbnails on upload for faster gallery loading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
         "ext-fileinfo": "*",
+        "ext-gd": "*",
         "ext-mbstring": "*",
         "league/oauth2-client": "^2.7",
         "league/oauth2-google": "^4.0",

--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -7,6 +7,7 @@ use Heirloom\Auth;
 use Heirloom\Database;
 use Heirloom\SiteSettings;
 use Heirloom\Template;
+use Heirloom\Thumbnail;
 
 class AdminController
 {
@@ -136,6 +137,11 @@ class AdminController
                 $errors[] = "$originalName: upload failed.";
                 continue;
             }
+
+            Thumbnail::generateThumbnail(
+                $uploadDir . $filename,
+                $uploadDir . Thumbnail::thumbFilename($filename)
+            );
 
             if ($fileCount === 1) {
                 $paintingTitle = $title;
@@ -311,7 +317,9 @@ class AdminController
         );
 
         if ($painting) {
-            @unlink(dirname(__DIR__, 2) . '/public/uploads/' . $painting['filename']);
+            $uploadDir = dirname(__DIR__, 2) . '/public/uploads/';
+            @unlink($uploadDir . $painting['filename']);
+            @unlink($uploadDir . Thumbnail::thumbFilename($painting['filename']));
             $this->db->execute('DELETE FROM paintings WHERE id = :id', [':id' => (int) $id]);
         }
 

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom;
+
+class Thumbnail
+{
+    /**
+     * Generate a thumbnail that fits within maxWidth while preserving aspect ratio.
+     * Does not upscale images smaller than maxWidth.
+     */
+    public static function generateThumbnail(string $sourcePath, string $destPath, int $maxWidth = 400): bool
+    {
+        $info = @getimagesize($sourcePath);
+        if ($info === false) {
+            return false;
+        }
+
+        $mime = $info['mime'];
+        $srcWidth = $info[0];
+        $srcHeight = $info[1];
+
+        $source = match ($mime) {
+            'image/jpeg' => @imagecreatefromjpeg($sourcePath),
+            'image/png' => @imagecreatefrompng($sourcePath),
+            default => false,
+        };
+
+        if ($source === false) {
+            return false;
+        }
+
+        // Don't upscale
+        if ($srcWidth <= $maxWidth) {
+            $newWidth = $srcWidth;
+            $newHeight = $srcHeight;
+        } else {
+            $newWidth = $maxWidth;
+            $newHeight = (int) round($srcHeight * ($maxWidth / $srcWidth));
+        }
+
+        $thumb = imagecreatetruecolor($newWidth, $newHeight);
+
+        // Preserve PNG transparency
+        if ($mime === 'image/png') {
+            imagealphablending($thumb, false);
+            imagesavealpha($thumb, true);
+        }
+
+        imagecopyresampled($thumb, $source, 0, 0, 0, 0, $newWidth, $newHeight, $srcWidth, $srcHeight);
+
+        $result = match ($mime) {
+            'image/jpeg' => imagejpeg($thumb, $destPath, 85),
+            'image/png' => imagepng($thumb, $destPath, 6),
+            default => false,
+        };
+
+        imagedestroy($source);
+        imagedestroy($thumb);
+
+        return $result;
+    }
+
+    /**
+     * Get the thumbnail filename for a given original filename.
+     * e.g., abc123.jpg -> abc123_thumb.jpg
+     */
+    public static function thumbFilename(string $filename): string
+    {
+        $ext = pathinfo($filename, PATHINFO_EXTENSION);
+        $base = pathinfo($filename, PATHINFO_FILENAME);
+        return $base . '_thumb.' . $ext;
+    }
+}

--- a/templates/gallery.php
+++ b/templates/gallery.php
@@ -1,4 +1,5 @@
-<?php use Heirloom\Template; ?>
+<?php use Heirloom\Template;
+use Heirloom\Thumbnail; ?>
 
 <div class="gallery-header">
     <h1>Paintings Available</h1>
@@ -13,7 +14,7 @@
             <div class="painting-card">
                 <a href="/painting/<?= $p['id'] ?>">
                     <img class="painting-card-image"
-                         src="/uploads/<?= Template::escape($p['filename']) ?>"
+                         src="/uploads/<?= Template::escape(Thumbnail::thumbFilename($p['filename'])) ?>"
                          alt="<?= Template::escape($p['title']) ?>"
                          loading="lazy">
                     <div class="painting-card-body">

--- a/tests/ThumbnailTest.php
+++ b/tests/ThumbnailTest.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Thumbnail;
+use PHPUnit\Framework\TestCase;
+
+class ThumbnailTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/heirloom_thumb_test_' . uniqid();
+        mkdir($this->tmpDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $files = glob($this->tmpDir . '/*');
+        if ($files) {
+            array_map('unlink', $files);
+        }
+        rmdir($this->tmpDir);
+    }
+
+    public function testGeneratesThumbnailSmallerThanOriginalJpeg(): void
+    {
+        $source = $this->tmpDir . '/original.jpg';
+        $dest = $this->tmpDir . '/original_thumb.jpg';
+
+        $img = imagecreatetruecolor(1200, 800);
+        imagejpeg($img, $source);
+        imagedestroy($img);
+
+        $result = Thumbnail::generateThumbnail($source, $dest, 400);
+
+        $this->assertTrue($result);
+        $this->assertFileExists($dest);
+
+        $info = getimagesize($dest);
+        $this->assertSame(400, $info[0]);
+        $this->assertLessThan(800, $info[1]);
+    }
+
+    public function testPreservesAspectRatio(): void
+    {
+        $source = $this->tmpDir . '/wide.jpg';
+        $dest = $this->tmpDir . '/wide_thumb.jpg';
+
+        // 1600x800 => aspect ratio 2:1
+        $img = imagecreatetruecolor(1600, 800);
+        imagejpeg($img, $source);
+        imagedestroy($img);
+
+        Thumbnail::generateThumbnail($source, $dest, 400);
+
+        $info = getimagesize($dest);
+        $this->assertSame(400, $info[0]);
+        $this->assertSame(200, $info[1]);
+    }
+
+    public function testHandlesPngFormat(): void
+    {
+        $source = $this->tmpDir . '/original.png';
+        $dest = $this->tmpDir . '/original_thumb.png';
+
+        $img = imagecreatetruecolor(1000, 500);
+        imagepng($img, $source);
+        imagedestroy($img);
+
+        $result = Thumbnail::generateThumbnail($source, $dest, 400);
+
+        $this->assertTrue($result);
+        $this->assertFileExists($dest);
+
+        $info = getimagesize($dest);
+        $this->assertSame(400, $info[0]);
+        $this->assertSame(200, $info[1]);
+        $this->assertSame(IMAGETYPE_PNG, $info[2]);
+    }
+
+    public function testHandlesJpegFormat(): void
+    {
+        $source = $this->tmpDir . '/photo.jpg';
+        $dest = $this->tmpDir . '/photo_thumb.jpg';
+
+        $img = imagecreatetruecolor(800, 600);
+        imagejpeg($img, $source);
+        imagedestroy($img);
+
+        Thumbnail::generateThumbnail($source, $dest, 400);
+
+        $info = getimagesize($dest);
+        $this->assertSame(IMAGETYPE_JPEG, $info[2]);
+    }
+
+    public function testReturnsFalseForUnsupportedFormat(): void
+    {
+        $source = $this->tmpDir . '/fake.bmp';
+        $dest = $this->tmpDir . '/fake_thumb.bmp';
+        file_put_contents($source, 'not a real image');
+
+        $result = Thumbnail::generateThumbnail($source, $dest);
+
+        $this->assertFalse($result);
+        $this->assertFileDoesNotExist($dest);
+    }
+
+    public function testDoesNotUpscaleSmallImages(): void
+    {
+        $source = $this->tmpDir . '/small.jpg';
+        $dest = $this->tmpDir . '/small_thumb.jpg';
+
+        $img = imagecreatetruecolor(200, 150);
+        imagejpeg($img, $source);
+        imagedestroy($img);
+
+        Thumbnail::generateThumbnail($source, $dest, 400);
+
+        $info = getimagesize($dest);
+        $this->assertSame(200, $info[0]);
+        $this->assertSame(150, $info[1]);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #27

- Adds `Thumbnail` class (`src/Thumbnail.php`) using PHP GD to generate resized thumbnails on upload, preserving aspect ratio and format (JPEG/PNG). Images smaller than `maxWidth` are not upscaled.
- `AdminController::upload()` now creates a `_thumb` variant (e.g., `abc123_thumb.jpg`) alongside each original. `AdminController::delete()` cleans up both files.
- `templates/gallery.php` serves the thumbnail in the grid for faster page loads; `templates/painting.php` still serves the full-size original.
- `ext-gd` added to `composer.json` require.

## Test plan

- [x] 6 new PHPUnit tests in `tests/ThumbnailTest.php` covering:
  - Thumbnail is smaller than original (JPEG)
  - Aspect ratio is preserved
  - PNG format handled correctly
  - JPEG format verified
  - Unsupported format returns false
  - Small images are not upscaled
- [x] All 149 tests and 29 specs pass (`composer check`)

Generated with [Claude Code](https://claude.com/claude-code)