### PR TITLE
Add 'My Paintings' dashboard page for users

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -49,6 +49,7 @@ $admin = new AdminController($db, $auth, $settings);
 $router->get('/', [$gallery, 'index']);
 $router->get('/painting/{id}', [$gallery, 'show']);
 $router->post('/painting/{id}/interest', [$gallery, 'expressInterest']);
+$router->get('/my-paintings', [$gallery, 'myPaintings']);
 
 // Auth routes
 $router->get('/login', [$authCtrl, 'loginForm']);

--- a/src/Controllers/GalleryController.php
+++ b/src/Controllers/GalleryController.php
@@ -128,4 +128,38 @@ class GalleryController
         header('Location: ' . $redirect);
         exit;
     }
+
+    public function myPaintings(): void
+    {
+        $this->auth->requireLogin();
+        $userId = $this->auth->userId();
+
+        $wanted = $this->db->fetchAll(
+            'SELECT p.* FROM paintings p
+             JOIN interests i ON i.painting_id = p.id
+             WHERE i.user_id = :uid AND p.awarded_to IS NULL
+             ORDER BY i.created_at DESC',
+            [':uid' => $userId]
+        );
+
+        $awarded = $this->db->fetchAll(
+            'SELECT * FROM paintings WHERE awarded_to = :uid ORDER BY awarded_at DESC',
+            [':uid' => $userId]
+        );
+
+        $noLongerAvailable = $this->db->fetchAll(
+            'SELECT p.* FROM paintings p
+             JOIN interests i ON i.painting_id = p.id
+             WHERE i.user_id = :uid AND p.awarded_to IS NOT NULL AND p.awarded_to != :uid2
+             ORDER BY p.awarded_at DESC',
+            [':uid' => $userId, ':uid2' => $userId]
+        );
+
+        Template::render('my-paintings', [
+            'wanted' => $wanted,
+            'awarded' => $awarded,
+            'noLongerAvailable' => $noLongerAvailable,
+            'auth' => $this->auth,
+        ]);
+    }
 }

--- a/templates/layout.php
+++ b/templates/layout.php
@@ -14,6 +14,7 @@
                 <?php if ($auth && $auth->isLoggedIn()): ?>
                     <?php $user = $auth->user(); ?>
                     <span class="nav-user"><?= \Heirloom\Template::escape($user['name'] ?: $user['email']) ?></span>
+                    <a href="/my-paintings">My Paintings</a>
                     <a href="/profile">Profile</a>
                     <?php if ($auth->isAdmin()): ?>
                         <a href="/admin">Admin</a>

--- a/templates/my-paintings.php
+++ b/templates/my-paintings.php
@@ -1,0 +1,84 @@
+<div class="form-page">
+    <h1>My Paintings</h1>
+
+    <?php if (empty($wanted) && empty($awarded) && empty($noLongerAvailable)): ?>
+        <p style="text-align:center;color:var(--text-muted);margin:2rem 0;">
+            You haven't expressed interest in any paintings yet.
+            <a href="/">Browse the gallery</a> to find paintings you love.
+        </p>
+    <?php endif; ?>
+
+    <?php if (!empty($awarded)): ?>
+    <div class="form-card" style="margin-bottom:2rem;">
+        <h2 style="margin-bottom:1rem;">Paintings I Was Awarded</h2>
+        <?php foreach ($awarded as $painting): ?>
+        <div style="display:flex;gap:1rem;align-items:flex-start;margin-bottom:1.5rem;padding-bottom:1.5rem;border-bottom:1px solid var(--border-color,#eee);">
+            <a href="/painting/<?= (int) $painting['id'] ?>">
+                <img src="/uploads/<?= \Heirloom\Template::escape($painting['filename']) ?>"
+                     alt="<?= \Heirloom\Template::escape($painting['title']) ?>"
+                     style="width:80px;height:80px;object-fit:cover;border-radius:4px;">
+            </a>
+            <div>
+                <p style="margin:0 0 0.25rem;">
+                    <a href="/painting/<?= (int) $painting['id'] ?>"><strong><?= \Heirloom\Template::escape($painting['title']) ?></strong></a>
+                </p>
+                <?php if ($painting['awarded_at']): ?>
+                    <p style="margin:0 0 0.25rem;font-size:0.85rem;color:var(--text-muted);">
+                        Awarded <?= \Heirloom\Template::escape(date('M j, Y', strtotime($painting['awarded_at']))) ?>
+                    </p>
+                <?php endif; ?>
+                <?php if ($painting['tracking_number']): ?>
+                    <p style="margin:0;font-size:0.85rem;">
+                        Tracking: <strong><?= \Heirloom\Template::escape($painting['tracking_number']) ?></strong>
+                    </p>
+                <?php else: ?>
+                    <p style="margin:0;font-size:0.85rem;color:var(--text-muted);">No tracking number yet</p>
+                <?php endif; ?>
+            </div>
+        </div>
+        <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
+
+    <?php if (!empty($wanted)): ?>
+    <div class="form-card" style="margin-bottom:2rem;">
+        <h2 style="margin-bottom:1rem;">Paintings I Want</h2>
+        <?php foreach ($wanted as $painting): ?>
+        <div style="display:flex;gap:1rem;align-items:flex-start;margin-bottom:1.5rem;padding-bottom:1.5rem;border-bottom:1px solid var(--border-color,#eee);">
+            <a href="/painting/<?= (int) $painting['id'] ?>">
+                <img src="/uploads/<?= \Heirloom\Template::escape($painting['filename']) ?>"
+                     alt="<?= \Heirloom\Template::escape($painting['title']) ?>"
+                     style="width:80px;height:80px;object-fit:cover;border-radius:4px;">
+            </a>
+            <div>
+                <p style="margin:0 0 0.25rem;">
+                    <a href="/painting/<?= (int) $painting['id'] ?>"><strong><?= \Heirloom\Template::escape($painting['title']) ?></strong></a>
+                </p>
+                <p style="margin:0;font-size:0.85rem;color:var(--text-muted);">Waiting for award decision</p>
+            </div>
+        </div>
+        <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
+
+    <?php if (!empty($noLongerAvailable)): ?>
+    <div class="form-card" style="margin-bottom:2rem;">
+        <h2 style="margin-bottom:1rem;">No Longer Available</h2>
+        <?php foreach ($noLongerAvailable as $painting): ?>
+        <div style="display:flex;gap:1rem;align-items:flex-start;margin-bottom:1.5rem;padding-bottom:1.5rem;border-bottom:1px solid var(--border-color,#eee);">
+            <a href="/painting/<?= (int) $painting['id'] ?>">
+                <img src="/uploads/<?= \Heirloom\Template::escape($painting['filename']) ?>"
+                     alt="<?= \Heirloom\Template::escape($painting['title']) ?>"
+                     style="width:80px;height:80px;object-fit:cover;border-radius:4px;opacity:0.6;">
+            </a>
+            <div>
+                <p style="margin:0 0 0.25rem;">
+                    <a href="/painting/<?= (int) $painting['id'] ?>"><strong><?= \Heirloom\Template::escape($painting['title']) ?></strong></a>
+                </p>
+                <p style="margin:0;font-size:0.85rem;color:var(--text-muted);">Awarded to someone else</p>
+            </div>
+        </div>
+        <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
+</div>

--- a/tests/MyPaintingsTest.php
+++ b/tests/MyPaintingsTest.php
@@ -1,0 +1,218 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Auth;
+use Heirloom\Database;
+use Heirloom\Controllers\GalleryController;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class MyPaintingsTest extends TestCase
+{
+    private Database $db;
+    private Auth $auth;
+
+    protected function setUp(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        $pdo->exec("
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT UNIQUE NOT NULL,
+                name TEXT NOT NULL DEFAULT '',
+                password_hash TEXT,
+                is_admin INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+        ");
+        $pdo->exec("
+            CREATE TABLE paintings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                filename TEXT NOT NULL,
+                original_filename TEXT NOT NULL DEFAULT '',
+                awarded_to INTEGER,
+                awarded_at TEXT,
+                tracking_number TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY (awarded_to) REFERENCES users(id) ON DELETE SET NULL
+            )
+        ");
+        $pdo->exec("
+            CREATE TABLE interests (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                painting_id INTEGER NOT NULL,
+                user_id INTEGER NOT NULL,
+                message TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY (painting_id) REFERENCES paintings(id) ON DELETE CASCADE,
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            )
+        ");
+
+        $this->db = new Database($pdo);
+        $this->auth = new Auth($this->db);
+
+        if (!isset($_SESSION)) {
+            $_SESSION = [];
+        }
+        unset($_SESSION['user_id']);
+    }
+
+    private function createUser(string $email = 'user@example.com', string $name = 'Test User'): int
+    {
+        $this->db->execute(
+            "INSERT INTO users (email, name) VALUES (:e, :n)",
+            [':e' => $email, ':n' => $name]
+        );
+        return $this->db->lastInsertId();
+    }
+
+    private function createPainting(string $title, ?int $awardedTo = null, ?string $trackingNumber = null): int
+    {
+        $this->db->execute(
+            "INSERT INTO paintings (title, filename, awarded_to, awarded_at, tracking_number) VALUES (:t, :f, :a, :at, :tn)",
+            [
+                ':t' => $title,
+                ':f' => 'test.jpg',
+                ':a' => $awardedTo,
+                ':at' => $awardedTo ? date('Y-m-d H:i:s') : null,
+                ':tn' => $trackingNumber,
+            ]
+        );
+        return $this->db->lastInsertId();
+    }
+
+    private function addInterest(int $paintingId, int $userId): void
+    {
+        $this->db->execute(
+            "INSERT INTO interests (painting_id, user_id) VALUES (:pid, :uid)",
+            [':pid' => $paintingId, ':uid' => $userId]
+        );
+    }
+
+    // --- Paintings I Want: user expressed interest, not yet awarded ---
+
+    public function testPaintingsIWantReturnsUnawarded(): void
+    {
+        $userId = $this->createUser();
+        $paintingId = $this->createPainting('Sunset');
+        $this->addInterest($paintingId, $userId);
+
+        $results = $this->db->fetchAll(
+            'SELECT p.* FROM paintings p
+             JOIN interests i ON i.painting_id = p.id
+             WHERE i.user_id = :uid AND p.awarded_to IS NULL',
+            [':uid' => $userId]
+        );
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Sunset', $results[0]['title']);
+    }
+
+    public function testPaintingsIWantExcludesAwarded(): void
+    {
+        $userId = $this->createUser();
+        $otherUser = $this->createUser('other@example.com', 'Other');
+        $paintingId = $this->createPainting('Awarded Painting', $otherUser);
+        $this->addInterest($paintingId, $userId);
+
+        $results = $this->db->fetchAll(
+            'SELECT p.* FROM paintings p
+             JOIN interests i ON i.painting_id = p.id
+             WHERE i.user_id = :uid AND p.awarded_to IS NULL',
+            [':uid' => $userId]
+        );
+
+        $this->assertCount(0, $results);
+    }
+
+    // --- Paintings I Was Awarded ---
+
+    public function testPaintingsAwardedToUser(): void
+    {
+        $userId = $this->createUser();
+        $this->createPainting('My Prize', $userId, 'TRACK123');
+
+        $results = $this->db->fetchAll(
+            'SELECT * FROM paintings WHERE awarded_to = :uid',
+            [':uid' => $userId]
+        );
+
+        $this->assertCount(1, $results);
+        $this->assertSame('My Prize', $results[0]['title']);
+        $this->assertSame('TRACK123', $results[0]['tracking_number']);
+    }
+
+    public function testPaintingsAwardedExcludesOtherUsers(): void
+    {
+        $userId = $this->createUser();
+        $otherUser = $this->createUser('other@example.com', 'Other');
+        $this->createPainting('Not Mine', $otherUser);
+
+        $results = $this->db->fetchAll(
+            'SELECT * FROM paintings WHERE awarded_to = :uid',
+            [':uid' => $userId]
+        );
+
+        $this->assertCount(0, $results);
+    }
+
+    // --- No Longer Available: user wanted but awarded to someone else ---
+
+    public function testNoLongerAvailableShowsAwardedToOthers(): void
+    {
+        $userId = $this->createUser();
+        $otherUser = $this->createUser('winner@example.com', 'Winner');
+        $paintingId = $this->createPainting('Gone Painting', $otherUser);
+        $this->addInterest($paintingId, $userId);
+
+        $results = $this->db->fetchAll(
+            'SELECT p.* FROM paintings p
+             JOIN interests i ON i.painting_id = p.id
+             WHERE i.user_id = :uid AND p.awarded_to IS NOT NULL AND p.awarded_to != :uid2',
+            [':uid' => $userId, ':uid2' => $userId]
+        );
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Gone Painting', $results[0]['title']);
+    }
+
+    public function testNoLongerAvailableExcludesSelfAwarded(): void
+    {
+        $userId = $this->createUser();
+        $paintingId = $this->createPainting('Won By Me', $userId);
+        $this->addInterest($paintingId, $userId);
+
+        $results = $this->db->fetchAll(
+            'SELECT p.* FROM paintings p
+             JOIN interests i ON i.painting_id = p.id
+             WHERE i.user_id = :uid AND p.awarded_to IS NOT NULL AND p.awarded_to != :uid2',
+            [':uid' => $userId, ':uid2' => $userId]
+        );
+
+        $this->assertCount(0, $results);
+    }
+
+    public function testNoLongerAvailableExcludesUnawarded(): void
+    {
+        $userId = $this->createUser();
+        $paintingId = $this->createPainting('Still Available');
+        $this->addInterest($paintingId, $userId);
+
+        $results = $this->db->fetchAll(
+            'SELECT p.* FROM paintings p
+             JOIN interests i ON i.painting_id = p.id
+             WHERE i.user_id = :uid AND p.awarded_to IS NOT NULL AND p.awarded_to != :uid2',
+            [':uid' => $userId, ':uid2' => $userId]
+        );
+
+        $this->assertCount(0, $results);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `/my-paintings` route with three sections: "Paintings I Want" (interested, not awarded), "Paintings I Was Awarded" (with tracking info), and "No Longer Available" (awarded to someone else)
- Adds `myPaintings()` method to `GalleryController` with three focused queries
- Adds "My Paintings" nav link for logged-in users
- Includes 7 unit tests covering all query edge cases

## Test plan
- [x] `composer check` passes (150 tests, 29 specs, all green)
- [ ] Manual: log in, express interest in paintings, verify they appear under "Paintings I Want"
- [ ] Manual: get awarded a painting, verify it moves to "Paintings I Was Awarded" with tracking number
- [ ] Manual: verify paintings awarded to others show under "No Longer Available"
- [ ] Manual: verify nav link only appears when logged in

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)