### PR TITLE
Add controller-level integration tests

### DIFF
--- a/tests/Controllers/AdminControllerTest.php
+++ b/tests/Controllers/AdminControllerTest.php
@@ -1,0 +1,517 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests\Controllers;
+
+use Heirloom\Database;
+use Heirloom\SiteSettings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the database queries used by AdminController.
+ *
+ * Exercises the exact SQL the controller relies on for dashboard queries,
+ * filtering, sorting, painting management, awarding, and unassigning.
+ */
+class AdminControllerTest extends TestCase
+{
+    use ControllerTestSchema;
+
+    private SiteSettings $settings;
+
+    protected function setUp(): void
+    {
+        $this->createDatabase();
+        $this->settings = new SiteSettings($this->db);
+    }
+
+    // ---------------------------------------------------------------
+    // Dashboard: filters
+    // ---------------------------------------------------------------
+
+    public function testDashboardFilterAvailableExcludesAwarded(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $this->insertPainting('Available');
+        $this->insertPainting('Awarded', $u);
+
+        $where = 'WHERE p.awarded_to IS NULL'; // default filter
+        $total = (int) $this->db->scalar("SELECT COUNT(*) FROM paintings p $where");
+
+        $this->assertSame(1, $total);
+    }
+
+    public function testDashboardFilterAwardedShowsOnlyAwarded(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $this->insertPainting('Available');
+        $this->insertPainting('Awarded', $u);
+
+        $where = 'WHERE p.awarded_to IS NOT NULL';
+        $total = (int) $this->db->scalar("SELECT COUNT(*) FROM paintings p $where");
+
+        $this->assertSame(1, $total);
+    }
+
+    public function testDashboardFilterAllReturnsEverything(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $this->insertPainting('Available');
+        $this->insertPainting('Awarded', $u);
+
+        $where = '';
+        $total = (int) $this->db->scalar("SELECT COUNT(*) FROM paintings p $where");
+
+        $this->assertSame(2, $total);
+    }
+
+    public function testDashboardFilterWantedShowsOnlyAvailableWithInterests(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $pWanted = $this->insertPainting('Wanted');
+        $this->insertPainting('Ignored');
+        $this->insertPainting('Awarded', $u);
+
+        $this->insertInterest($pWanted, $u);
+
+        $where = 'WHERE p.awarded_to IS NULL AND EXISTS (SELECT 1 FROM interests i2 WHERE i2.painting_id = p.id)';
+        $total = (int) $this->db->scalar("SELECT COUNT(*) FROM paintings p $where");
+
+        $this->assertSame(1, $total);
+    }
+
+    // ---------------------------------------------------------------
+    // Dashboard: sort direction whitelist
+    // ---------------------------------------------------------------
+
+    public function testSortDirectionWhitelist(): void
+    {
+        // Mirrors the controller logic
+        $dir = strtolower('desc') === 'asc' ? 'ASC' : 'DESC';
+        $this->assertSame('DESC', $dir);
+
+        $dir = strtolower('asc') === 'asc' ? 'ASC' : 'DESC';
+        $this->assertSame('ASC', $dir);
+
+        $dir = strtolower('DROP TABLE') === 'asc' ? 'ASC' : 'DESC';
+        $this->assertSame('DESC', $dir);
+    }
+
+    // ---------------------------------------------------------------
+    // Dashboard: allowed sort columns
+    // ---------------------------------------------------------------
+
+    public function testAllowedSortColumnsMapping(): void
+    {
+        $allowedSorts = [
+            'title' => 'p.title',
+            'interest_count' => 'interest_count',
+            'last_interest_at' => 'last_interest_at',
+            'created_at' => 'p.created_at',
+        ];
+
+        $this->assertSame('p.title', $allowedSorts['title'] ?? 'p.created_at');
+        $this->assertSame('p.created_at', $allowedSorts['bogus'] ?? 'p.created_at');
+    }
+
+    // ---------------------------------------------------------------
+    // Dashboard: full query with interest_count and last_interest_at
+    // ---------------------------------------------------------------
+
+    public function testDashboardQueryReturnsInterestCountAndLastInterest(): void
+    {
+        $admin = $this->insertUser('admin@test.com', 'Admin', true);
+        $u1 = $this->insertUser('a@test.com', 'A');
+        $u2 = $this->insertUser('b@test.com', 'B');
+
+        $p = $this->insertPainting('Painting');
+        $this->insertInterest($p, $u1, '', '2025-01-01 10:00:00');
+        $this->insertInterest($p, $u2, '', '2025-06-15 14:00:00');
+
+        $where = 'WHERE p.awarded_to IS NULL';
+        $paintings = $this->db->fetchAll(
+            "SELECT p.*,
+                (SELECT COUNT(*) FROM interests i WHERE i.painting_id = p.id) AS interest_count,
+                (SELECT MAX(i3.created_at) FROM interests i3 WHERE i3.painting_id = p.id) AS last_interest_at,
+                u.name AS awarded_name, u.email AS awarded_email
+             FROM paintings p
+             LEFT JOIN users u ON u.id = p.awarded_to
+             $where
+             ORDER BY p.created_at DESC
+             LIMIT :limit OFFSET :offset",
+            [':limit' => 20, ':offset' => 0]
+        );
+
+        $this->assertCount(1, $paintings);
+        $this->assertSame(2, (int) $paintings[0]['interest_count']);
+        $this->assertSame('2025-06-15 14:00:00', $paintings[0]['last_interest_at']);
+        $this->assertNull($paintings[0]['awarded_name']);
+    }
+
+    public function testDashboardQueryShowsAwardedUserInfo(): void
+    {
+        $recipient = $this->insertUser('winner@test.com', 'Alice');
+        $this->insertPainting('Gift', $recipient);
+
+        $where = 'WHERE p.awarded_to IS NOT NULL';
+        $paintings = $this->db->fetchAll(
+            "SELECT p.*,
+                (SELECT COUNT(*) FROM interests i WHERE i.painting_id = p.id) AS interest_count,
+                (SELECT MAX(i3.created_at) FROM interests i3 WHERE i3.painting_id = p.id) AS last_interest_at,
+                u.name AS awarded_name, u.email AS awarded_email
+             FROM paintings p
+             LEFT JOIN users u ON u.id = p.awarded_to
+             $where
+             ORDER BY p.created_at DESC
+             LIMIT :limit OFFSET :offset",
+            [':limit' => 20, ':offset' => 0]
+        );
+
+        $this->assertCount(1, $paintings);
+        $this->assertSame('Alice', $paintings[0]['awarded_name']);
+        $this->assertSame('winner@test.com', $paintings[0]['awarded_email']);
+    }
+
+    public function testDashboardQuerySortByTitle(): void
+    {
+        $this->insertPainting('Zebra');
+        $this->insertPainting('Apple');
+        $this->insertPainting('Mango');
+
+        $paintings = $this->db->fetchAll(
+            "SELECT p.*,
+                (SELECT COUNT(*) FROM interests i WHERE i.painting_id = p.id) AS interest_count,
+                (SELECT MAX(i3.created_at) FROM interests i3 WHERE i3.painting_id = p.id) AS last_interest_at,
+                u.name AS awarded_name, u.email AS awarded_email
+             FROM paintings p
+             LEFT JOIN users u ON u.id = p.awarded_to
+             WHERE p.awarded_to IS NULL
+             ORDER BY p.title ASC
+             LIMIT :limit OFFSET :offset",
+            [':limit' => 20, ':offset' => 0]
+        );
+
+        $this->assertSame('Apple', $paintings[0]['title']);
+        $this->assertSame('Mango', $paintings[1]['title']);
+        $this->assertSame('Zebra', $paintings[2]['title']);
+    }
+
+    public function testDashboardQuerySortByInterestCount(): void
+    {
+        $u1 = $this->insertUser('a@test.com');
+        $u2 = $this->insertUser('b@test.com');
+
+        $pLow = $this->insertPainting('Low');
+        $pHigh = $this->insertPainting('High');
+
+        $this->insertInterest($pHigh, $u1);
+        $this->insertInterest($pHigh, $u2);
+        $this->insertInterest($pLow, $u1);
+
+        $paintings = $this->db->fetchAll(
+            "SELECT p.*,
+                (SELECT COUNT(*) FROM interests i WHERE i.painting_id = p.id) AS interest_count,
+                (SELECT MAX(i3.created_at) FROM interests i3 WHERE i3.painting_id = p.id) AS last_interest_at,
+                u.name AS awarded_name, u.email AS awarded_email
+             FROM paintings p
+             LEFT JOIN users u ON u.id = p.awarded_to
+             WHERE p.awarded_to IS NULL
+             ORDER BY interest_count DESC
+             LIMIT :limit OFFSET :offset",
+            [':limit' => 20, ':offset' => 0]
+        );
+
+        $this->assertSame('High', $paintings[0]['title']);
+        $this->assertSame('Low', $paintings[1]['title']);
+    }
+
+    // ---------------------------------------------------------------
+    // Manage painting: interests with user info
+    // ---------------------------------------------------------------
+
+    public function testManagePaintingInterestsQuery(): void
+    {
+        $u1 = $this->insertUser('alice@test.com', 'Alice');
+        $u2 = $this->insertUser('bob@test.com', 'Bob');
+
+        $p = $this->insertPainting('P');
+        $this->insertInterest($p, $u1, 'Please!', '2025-01-01 00:00:00');
+        $this->insertInterest($p, $u2, 'Me too!', '2025-01-02 00:00:00');
+
+        $interests = $this->db->fetchAll(
+            'SELECT i.*, u.name, u.email, u.shipping_address FROM interests i
+             JOIN users u ON u.id = i.user_id
+             WHERE i.painting_id = :pid
+             ORDER BY i.created_at ASC',
+            [':pid' => $p]
+        );
+
+        $this->assertCount(2, $interests);
+        $this->assertSame('Alice', $interests[0]['name']);
+        $this->assertSame('alice@test.com', $interests[0]['email']);
+        $this->assertSame('Please!', $interests[0]['message']);
+        $this->assertSame('Bob', $interests[1]['name']);
+    }
+
+    public function testManagePaintingAwardedUserLookup(): void
+    {
+        $u = $this->insertUser('winner@test.com', 'Winner');
+        $this->db->execute(
+            'UPDATE users SET shipping_address = :a WHERE id = :id',
+            [':a' => '123 Main St', ':id' => $u]
+        );
+
+        $p = $this->insertPainting('Gift', $u);
+        $painting = $this->db->fetchOne('SELECT * FROM paintings WHERE id = :id', [':id' => $p]);
+
+        $awardedUser = $this->db->fetchOne(
+            'SELECT id, name, email, shipping_address FROM users WHERE id = :id',
+            [':id' => $painting['awarded_to']]
+        );
+
+        $this->assertNotNull($awardedUser);
+        $this->assertSame('Winner', $awardedUser['name']);
+        $this->assertSame('123 Main St', $awardedUser['shipping_address']);
+    }
+
+    // ---------------------------------------------------------------
+    // Award painting: update + log
+    // ---------------------------------------------------------------
+
+    public function testAwardPaintingUpdatesRow(): void
+    {
+        $admin = $this->insertUser('admin@test.com', 'Admin', true);
+        $user = $this->insertUser('user@test.com', 'User');
+        $p = $this->insertPainting('Prize');
+
+        $this->db->execute(
+            'UPDATE paintings SET awarded_to = :uid, awarded_at = datetime(\'now\') WHERE id = :id',
+            [':uid' => $user, ':id' => $p]
+        );
+
+        $painting = $this->db->fetchOne('SELECT * FROM paintings WHERE id = :id', [':id' => $p]);
+        $this->assertSame($user, (int) $painting['awarded_to']);
+        $this->assertNotNull($painting['awarded_at']);
+    }
+
+    public function testAwardPaintingCreatesLogEntry(): void
+    {
+        $admin = $this->insertUser('admin@test.com', 'Admin', true);
+        $user = $this->insertUser('user@test.com', 'User');
+        $p = $this->insertPainting('Prize');
+
+        $this->db->execute(
+            'INSERT INTO award_log (painting_id, user_id, awarded_by, action) VALUES (:pid, :uid, :aid, :action)',
+            [':pid' => $p, ':uid' => $user, ':aid' => $admin, ':action' => 'awarded']
+        );
+
+        $log = $this->db->fetchAll('SELECT * FROM award_log WHERE painting_id = :pid', [':pid' => $p]);
+        $this->assertCount(1, $log);
+        $this->assertSame('awarded', $log[0]['action']);
+        $this->assertSame($user, (int) $log[0]['user_id']);
+        $this->assertSame($admin, (int) $log[0]['awarded_by']);
+    }
+
+    // ---------------------------------------------------------------
+    // Unassign painting: clear + log
+    // ---------------------------------------------------------------
+
+    public function testUnassignPaintingClearsFields(): void
+    {
+        $user = $this->insertUser('user@test.com');
+        $p = $this->insertPainting('Prize', $user);
+
+        $this->db->execute(
+            'UPDATE paintings SET awarded_to = NULL, awarded_at = NULL, tracking_number = NULL WHERE id = :id',
+            [':id' => $p]
+        );
+
+        $painting = $this->db->fetchOne('SELECT * FROM paintings WHERE id = :id', [':id' => $p]);
+        $this->assertNull($painting['awarded_to']);
+        $this->assertNull($painting['awarded_at']);
+        $this->assertNull($painting['tracking_number']);
+    }
+
+    public function testUnassignPaintingCreatesLogEntry(): void
+    {
+        $admin = $this->insertUser('admin@test.com', 'Admin', true);
+        $user = $this->insertUser('user@test.com', 'User');
+        $p = $this->insertPainting('Prize', $user);
+
+        $painting = $this->db->fetchOne('SELECT awarded_to FROM paintings WHERE id = :id', [':id' => $p]);
+
+        $this->db->execute(
+            'INSERT INTO award_log (painting_id, user_id, awarded_by, action) VALUES (:pid, :uid, :aid, :action)',
+            [':pid' => $p, ':uid' => $painting['awarded_to'], ':aid' => $admin, ':action' => 'unassigned']
+        );
+
+        $log = $this->db->fetchAll('SELECT * FROM award_log WHERE painting_id = :pid', [':pid' => $p]);
+        $this->assertCount(1, $log);
+        $this->assertSame('unassigned', $log[0]['action']);
+    }
+
+    // ---------------------------------------------------------------
+    // Award log query (with user joins)
+    // ---------------------------------------------------------------
+
+    public function testAwardLogQueryWithJoins(): void
+    {
+        $admin = $this->insertUser('admin@test.com', 'Admin', true);
+        $user = $this->insertUser('user@test.com', 'User');
+        $p = $this->insertPainting('Art');
+
+        $this->db->execute(
+            'INSERT INTO award_log (painting_id, user_id, awarded_by, action, created_at)
+             VALUES (:pid, :uid, :aid, :action, :at)',
+            [':pid' => $p, ':uid' => $user, ':aid' => $admin, ':action' => 'awarded', ':at' => '2025-01-01 12:00:00']
+        );
+        $this->db->execute(
+            'INSERT INTO award_log (painting_id, user_id, awarded_by, action, created_at)
+             VALUES (:pid, :uid, :aid, :action, :at)',
+            [':pid' => $p, ':uid' => $user, ':aid' => $admin, ':action' => 'unassigned', ':at' => '2025-02-01 12:00:00']
+        );
+
+        $awardLog = $this->db->fetchAll(
+            'SELECT al.*, u.name AS user_name, u.email AS user_email, adm.name AS admin_name
+             FROM award_log al
+             JOIN users u ON u.id = al.user_id
+             JOIN users adm ON adm.id = al.awarded_by
+             WHERE al.painting_id = :pid
+             ORDER BY al.created_at DESC',
+            [':pid' => $p]
+        );
+
+        $this->assertCount(2, $awardLog);
+        $this->assertSame('unassigned', $awardLog[0]['action']); // most recent first
+        $this->assertSame('awarded', $awardLog[1]['action']);
+        $this->assertSame('User', $awardLog[0]['user_name']);
+        $this->assertSame('Admin', $awardLog[0]['admin_name']);
+    }
+
+    // ---------------------------------------------------------------
+    // Edit painting
+    // ---------------------------------------------------------------
+
+    public function testEditPaintingUpdatesFields(): void
+    {
+        $p = $this->insertPainting('Old Title', null, 'Old desc');
+
+        $this->db->execute(
+            'UPDATE paintings SET title = :title, description = :desc WHERE id = :id',
+            [':title' => 'New Title', ':desc' => 'New desc', ':id' => $p]
+        );
+
+        $painting = $this->db->fetchOne('SELECT * FROM paintings WHERE id = :id', [':id' => $p]);
+        $this->assertSame('New Title', $painting['title']);
+        $this->assertSame('New desc', $painting['description']);
+    }
+
+    // ---------------------------------------------------------------
+    // Update tracking number
+    // ---------------------------------------------------------------
+
+    public function testUpdateTrackingNumber(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $p = $this->insertPainting('Prize', $u);
+
+        $this->db->execute(
+            'UPDATE paintings SET tracking_number = :tn WHERE id = :id',
+            [':tn' => 'TRACK123', ':id' => $p]
+        );
+
+        $painting = $this->db->fetchOne('SELECT * FROM paintings WHERE id = :id', [':id' => $p]);
+        $this->assertSame('TRACK123', $painting['tracking_number']);
+    }
+
+    public function testUpdateTrackingNumberToNull(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $p = $this->insertPainting('Prize', $u);
+
+        $this->db->execute(
+            'UPDATE paintings SET tracking_number = :tn WHERE id = :id',
+            [':tn' => 'TRACK123', ':id' => $p]
+        );
+
+        $this->db->execute(
+            'UPDATE paintings SET tracking_number = :tn WHERE id = :id',
+            [':tn' => null, ':id' => $p]
+        );
+
+        $painting = $this->db->fetchOne('SELECT * FROM paintings WHERE id = :id', [':id' => $p]);
+        $this->assertNull($painting['tracking_number']);
+    }
+
+    // ---------------------------------------------------------------
+    // Delete painting
+    // ---------------------------------------------------------------
+
+    public function testDeletePaintingRemovesRow(): void
+    {
+        $p = $this->insertPainting('Doomed');
+
+        $painting = $this->db->fetchOne('SELECT filename FROM paintings WHERE id = :id', [':id' => $p]);
+        $this->assertNotNull($painting);
+
+        $this->db->execute('DELETE FROM paintings WHERE id = :id', [':id' => $p]);
+
+        $deleted = $this->db->fetchOne('SELECT * FROM paintings WHERE id = :id', [':id' => $p]);
+        $this->assertNull($deleted);
+    }
+
+    // ---------------------------------------------------------------
+    // Admin per-page setting
+    // ---------------------------------------------------------------
+
+    public function testAdminPerPageSetting(): void
+    {
+        $this->insertSetting('admin_per_page', '50');
+        $perPage = $this->settings->getInt('admin_per_page', 20);
+        $this->assertSame(50, $perPage);
+    }
+
+    public function testAdminPerPageDefaultsTo20(): void
+    {
+        $perPage = $this->settings->getInt('admin_per_page', 20);
+        $this->assertSame(20, $perPage);
+    }
+
+    // ---------------------------------------------------------------
+    // Upload: insert painting row
+    // ---------------------------------------------------------------
+
+    public function testUploadInsertsPaintingRow(): void
+    {
+        $this->db->execute(
+            'INSERT INTO paintings (title, description, filename, original_filename) VALUES (:title, :desc, :file, :orig)',
+            [':title' => 'New Art', ':desc' => 'A painting', ':file' => 'abc123.jpg', ':orig' => 'my_painting.jpg']
+        );
+
+        $painting = $this->db->fetchOne('SELECT * FROM paintings WHERE title = :t', [':t' => 'New Art']);
+        $this->assertNotNull($painting);
+        $this->assertSame('abc123.jpg', $painting['filename']);
+        $this->assertSame('my_painting.jpg', $painting['original_filename']);
+        $this->assertNull($painting['awarded_to']);
+    }
+
+    // ---------------------------------------------------------------
+    // Upload: title generation for multi-file uploads
+    // ---------------------------------------------------------------
+
+    public function testMultiFileUploadTitleWithPrefix(): void
+    {
+        $title = 'Series';
+        $baseName = 'painting_01';
+        $paintingTitle = $title !== '' ? $title . ' - ' . $baseName : $baseName;
+        $this->assertSame('Series - painting_01', $paintingTitle);
+    }
+
+    public function testMultiFileUploadTitleWithoutPrefix(): void
+    {
+        $title = '';
+        $baseName = 'painting_01';
+        $paintingTitle = $title !== '' ? $title . ' - ' . $baseName : $baseName;
+        $this->assertSame('painting_01', $paintingTitle);
+    }
+}

--- a/tests/Controllers/AuthControllerTest.php
+++ b/tests/Controllers/AuthControllerTest.php
@@ -1,0 +1,341 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests\Controllers;
+
+use Heirloom\Auth;
+use Heirloom\Database;
+use Heirloom\RateLimiter;
+use Heirloom\SiteSettings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the database queries and logic used by AuthController.
+ *
+ * Tests the Auth/RateLimiter/Database methods that the controller relies on,
+ * since the controller methods themselves call header()/exit().
+ */
+class AuthControllerTest extends TestCase
+{
+    use ControllerTestSchema;
+
+    private SiteSettings $settings;
+
+    protected function setUp(): void
+    {
+        $this->createDatabase();
+        $this->settings = new SiteSettings($this->db);
+    }
+
+    // ---------------------------------------------------------------
+    // Email normalization
+    // ---------------------------------------------------------------
+
+    public function testEmailNormalization(): void
+    {
+        $this->assertSame('test@example.com', Auth::normalizeEmail('  Test@Example.COM  '));
+    }
+
+    // ---------------------------------------------------------------
+    // Rate limiter: recording and checking attempts
+    // ---------------------------------------------------------------
+
+    public function testRateLimiterAllowsWithinLimit(): void
+    {
+        $limiter = new RateLimiter($this->db, 3, 15);
+
+        $this->assertTrue($limiter->isAllowed('user@test.com'));
+        $limiter->record('user@test.com');
+        $limiter->record('user@test.com');
+
+        $this->assertTrue($limiter->isAllowed('user@test.com'));
+        $this->assertSame(1, $limiter->remainingAttempts('user@test.com'));
+    }
+
+    public function testRateLimiterBlocksAfterMax(): void
+    {
+        $limiter = new RateLimiter($this->db, 2, 15);
+
+        $limiter->record('user@test.com');
+        $limiter->record('user@test.com');
+
+        $this->assertFalse($limiter->isAllowed('user@test.com'));
+        $this->assertSame(0, $limiter->remainingAttempts('user@test.com'));
+    }
+
+    public function testRateLimiterClearResetsAttempts(): void
+    {
+        $limiter = new RateLimiter($this->db, 2, 15);
+
+        $limiter->record('user@test.com');
+        $limiter->record('user@test.com');
+        $this->assertFalse($limiter->isAllowed('user@test.com'));
+
+        $limiter->clear('user@test.com');
+        $this->assertTrue($limiter->isAllowed('user@test.com'));
+    }
+
+    public function testRateLimiterIsolatesIdentifiers(): void
+    {
+        $limiter = new RateLimiter($this->db, 2, 15);
+
+        $limiter->record('alice@test.com');
+        $limiter->record('alice@test.com');
+
+        $this->assertFalse($limiter->isAllowed('alice@test.com'));
+        $this->assertTrue($limiter->isAllowed('bob@test.com'));
+    }
+
+    // ---------------------------------------------------------------
+    // Password login
+    // ---------------------------------------------------------------
+
+    public function testAttemptPasswordLoginSucceeds(): void
+    {
+        $hash = password_hash('secret123', PASSWORD_DEFAULT);
+        $this->insertUser('alice@test.com', 'Alice', false, $hash);
+
+        $auth = new Auth($this->db);
+        $user = $auth->attemptPasswordLogin('alice@test.com', 'secret123');
+
+        $this->assertNotNull($user);
+        $this->assertSame('alice@test.com', $user['email']);
+    }
+
+    public function testAttemptPasswordLoginFailsWithWrongPassword(): void
+    {
+        $hash = password_hash('secret123', PASSWORD_DEFAULT);
+        $this->insertUser('alice@test.com', 'Alice', false, $hash);
+
+        $auth = new Auth($this->db);
+        $user = $auth->attemptPasswordLogin('alice@test.com', 'wrongpass');
+
+        $this->assertNull($user);
+    }
+
+    public function testAttemptPasswordLoginFailsForNonexistentUser(): void
+    {
+        $auth = new Auth($this->db);
+        $user = $auth->attemptPasswordLogin('nobody@test.com', 'anything');
+
+        $this->assertNull($user);
+    }
+
+    public function testAttemptPasswordLoginFailsWhenNoPasswordHash(): void
+    {
+        $this->insertUser('alice@test.com', 'Alice');
+
+        $auth = new Auth($this->db);
+        $user = $auth->attemptPasswordLogin('alice@test.com', 'anything');
+
+        $this->assertNull($user);
+    }
+
+    // ---------------------------------------------------------------
+    // Find / create user
+    // ---------------------------------------------------------------
+
+    public function testFindUserByEmail(): void
+    {
+        $this->insertUser('alice@test.com', 'Alice');
+
+        $auth = new Auth($this->db);
+        $user = $auth->findUserByEmail('alice@test.com');
+
+        $this->assertNotNull($user);
+        $this->assertSame('Alice', $user['name']);
+    }
+
+    public function testFindUserByEmailReturnsNullWhenMissing(): void
+    {
+        $auth = new Auth($this->db);
+        $user = $auth->findUserByEmail('nobody@test.com');
+
+        $this->assertNull($user);
+    }
+
+    public function testFindOrCreateUserCreatesNewUser(): void
+    {
+        $auth = new Auth($this->db);
+        $user = $auth->findOrCreateUserByEmail('new@test.com', 'New Person');
+
+        $this->assertNotNull($user);
+        $this->assertSame('new@test.com', $user['email']);
+        $this->assertSame('New Person', $user['name']);
+
+        // Verify actually persisted
+        $dbUser = $this->db->fetchOne('SELECT * FROM users WHERE email = :e', [':e' => 'new@test.com']);
+        $this->assertNotNull($dbUser);
+    }
+
+    public function testFindOrCreateUserReturnsExistingUser(): void
+    {
+        $existingId = $this->insertUser('existing@test.com', 'Existing');
+
+        $auth = new Auth($this->db);
+        $user = $auth->findOrCreateUserByEmail('existing@test.com', 'Different Name');
+
+        $this->assertSame($existingId, (int) $user['id']);
+        $this->assertSame('Existing', $user['name']); // name not overwritten
+    }
+
+    // ---------------------------------------------------------------
+    // Magic links
+    // ---------------------------------------------------------------
+
+    public function testCreateMagicLinkInsertsToken(): void
+    {
+        $auth = new Auth($this->db);
+        $token = $auth->createMagicLink('alice@test.com');
+
+        $this->assertNotEmpty($token);
+
+        $row = $this->db->fetchOne('SELECT * FROM magic_links WHERE token = :t', [':t' => $token]);
+        $this->assertNotNull($row);
+        $this->assertSame('alice@test.com', $row['email']);
+        $this->assertSame('0', (string) $row['used']);
+    }
+
+    public function testCreateMagicLinkGeneratesUniqueTokens(): void
+    {
+        $auth = new Auth($this->db);
+        $t1 = $auth->createMagicLink('alice@test.com');
+        $t2 = $auth->createMagicLink('alice@test.com');
+
+        $this->assertNotSame($t1, $t2);
+    }
+
+    // ---------------------------------------------------------------
+    // Set password (DB update)
+    // ---------------------------------------------------------------
+
+    public function testSetPasswordUpdatesHash(): void
+    {
+        $uid = $this->insertUser('alice@test.com', 'Alice');
+
+        $hash = password_hash('newpass123', PASSWORD_DEFAULT);
+        $this->db->execute(
+            'UPDATE users SET password_hash = :hash WHERE id = :id',
+            [':hash' => $hash, ':id' => $uid]
+        );
+
+        $user = $this->db->fetchOne('SELECT * FROM users WHERE id = :id', [':id' => $uid]);
+        $this->assertTrue(password_verify('newpass123', $user['password_hash']));
+    }
+
+    // ---------------------------------------------------------------
+    // Profile: awarded paintings query
+    // ---------------------------------------------------------------
+
+    public function testProfileAwardedPaintingsQuery(): void
+    {
+        $u = $this->insertUser('winner@test.com', 'Winner');
+
+        $this->insertPainting('Not awarded');
+
+        $this->db->execute(
+            "INSERT INTO paintings (title, filename, original_filename, awarded_to, awarded_at, tracking_number, created_at)
+             VALUES (:t, :f, :o, :a, :at, :tn, :ca)",
+            [':t' => 'Prize 1', ':f' => 'a.jpg', ':o' => 'a.jpg', ':a' => $u, ':at' => '2025-03-01 12:00:00', ':tn' => 'TRACK1', ':ca' => '2025-01-01 00:00:00']
+        );
+        $this->db->execute(
+            "INSERT INTO paintings (title, filename, original_filename, awarded_to, awarded_at, tracking_number, created_at)
+             VALUES (:t, :f, :o, :a, :at, :tn, :ca)",
+            [':t' => 'Prize 2', ':f' => 'b.jpg', ':o' => 'b.jpg', ':a' => $u, ':at' => '2025-06-01 12:00:00', ':tn' => null, ':ca' => '2025-02-01 00:00:00']
+        );
+
+        $awardedPaintings = $this->db->fetchAll(
+            'SELECT p.title, p.filename, p.awarded_at, p.tracking_number FROM paintings p WHERE p.awarded_to = :uid ORDER BY p.awarded_at DESC',
+            [':uid' => $u]
+        );
+
+        $this->assertCount(2, $awardedPaintings);
+        $this->assertSame('Prize 2', $awardedPaintings[0]['title']); // most recent first
+        $this->assertSame('Prize 1', $awardedPaintings[1]['title']);
+        $this->assertSame('TRACK1', $awardedPaintings[1]['tracking_number']);
+        $this->assertNull($awardedPaintings[0]['tracking_number']);
+    }
+
+    public function testProfileAwardedPaintingsQueryReturnsEmptyWhenNone(): void
+    {
+        $u = $this->insertUser('noprizes@test.com');
+
+        $awardedPaintings = $this->db->fetchAll(
+            'SELECT p.title, p.filename, p.awarded_at, p.tracking_number FROM paintings p WHERE p.awarded_to = :uid ORDER BY p.awarded_at DESC',
+            [':uid' => $u]
+        );
+
+        $this->assertSame([], $awardedPaintings);
+    }
+
+    // ---------------------------------------------------------------
+    // Update shipping address
+    // ---------------------------------------------------------------
+
+    public function testUpdateShippingAddress(): void
+    {
+        $uid = $this->insertUser('u@test.com');
+
+        $this->db->execute(
+            'UPDATE users SET shipping_address = :addr WHERE id = :id',
+            [':addr' => '123 Elm St, Springfield', ':id' => $uid]
+        );
+
+        $user = $this->db->fetchOne('SELECT * FROM users WHERE id = :id', [':id' => $uid]);
+        $this->assertSame('123 Elm St, Springfield', $user['shipping_address']);
+    }
+
+    public function testUpdateShippingAddressToNull(): void
+    {
+        $uid = $this->insertUser('u@test.com');
+        $this->db->execute(
+            'UPDATE users SET shipping_address = :addr WHERE id = :id',
+            [':addr' => '123 Elm St', ':id' => $uid]
+        );
+
+        $this->db->execute(
+            'UPDATE users SET shipping_address = :addr WHERE id = :id',
+            [':addr' => null, ':id' => $uid]
+        );
+
+        $user = $this->db->fetchOne('SELECT * FROM users WHERE id = :id', [':id' => $uid]);
+        $this->assertNull($user['shipping_address']);
+    }
+
+    // ---------------------------------------------------------------
+    // Registration closed setting
+    // ---------------------------------------------------------------
+
+    public function testRegistrationClosedSetting(): void
+    {
+        $this->insertSetting('registration_open', '0');
+        $this->assertFalse($this->settings->getBool('registration_open', true));
+    }
+
+    public function testRegistrationOpenByDefault(): void
+    {
+        $this->assertTrue($this->settings->getBool('registration_open', true));
+    }
+
+    // ---------------------------------------------------------------
+    // Redirect safety (mirrors Auth::consumeRedirect logic)
+    // ---------------------------------------------------------------
+
+    public function testRedirectSafetyRejectsExternalUrls(): void
+    {
+        $testCases = [
+            '/' => '/',
+            '/gallery' => '/gallery',
+            '//evil.com' => '/',
+            'http://evil.com' => '/',
+        ];
+
+        foreach ($testCases as $input => $expected) {
+            $redirect = $input;
+            if (!str_starts_with($redirect, '/') || str_starts_with($redirect, '//')) {
+                $redirect = '/';
+            }
+            $this->assertSame($expected, $redirect, "Failed for input: $input");
+        }
+    }
+}

--- a/tests/Controllers/ControllerTestSchema.php
+++ b/tests/Controllers/ControllerTestSchema.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests\Controllers;
+
+use Heirloom\Database;
+use PDO;
+
+/**
+ * Trait providing an in-memory SQLite database with the full Heirloom schema.
+ *
+ * SQLite differences from MySQL that we accommodate:
+ * - AUTOINCREMENT instead of AUTO_INCREMENT
+ * - DATETIME columns stored as TEXT; NOW() replaced with datetime('now')
+ * - BOOLEAN stored as INTEGER (0/1)
+ */
+trait ControllerTestSchema
+{
+    private PDO $pdo;
+    private Database $db;
+
+    private function createDatabase(): Database
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        $this->pdo->exec('CREATE TABLE users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email TEXT NOT NULL UNIQUE,
+            name TEXT NOT NULL DEFAULT \'\',
+            password_hash TEXT,
+            shipping_address TEXT,
+            is_admin INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL DEFAULT (datetime(\'now\'))
+        )');
+
+        $this->pdo->exec('CREATE TABLE paintings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT \'\',
+            filename TEXT NOT NULL DEFAULT \'\',
+            original_filename TEXT NOT NULL DEFAULT \'\',
+            awarded_to INTEGER,
+            awarded_at TEXT,
+            tracking_number TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime(\'now\')),
+            FOREIGN KEY (awarded_to) REFERENCES users(id)
+        )');
+
+        $this->pdo->exec('CREATE TABLE interests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            painting_id INTEGER NOT NULL,
+            user_id INTEGER NOT NULL,
+            message TEXT NOT NULL DEFAULT \'\',
+            created_at TEXT NOT NULL DEFAULT (datetime(\'now\')),
+            FOREIGN KEY (painting_id) REFERENCES paintings(id),
+            FOREIGN KEY (user_id) REFERENCES users(id),
+            UNIQUE(painting_id, user_id)
+        )');
+
+        $this->pdo->exec('CREATE TABLE magic_links (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email TEXT NOT NULL,
+            token TEXT NOT NULL,
+            used INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL DEFAULT (datetime(\'now\'))
+        )');
+
+        $this->pdo->exec('CREATE TABLE site_settings (
+            setting_key TEXT PRIMARY KEY,
+            setting_value TEXT NOT NULL,
+            label TEXT NOT NULL DEFAULT \'\',
+            description TEXT NOT NULL DEFAULT \'\'
+        )');
+
+        $this->pdo->exec('CREATE TABLE login_attempts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            identifier TEXT NOT NULL,
+            attempted_at TEXT NOT NULL DEFAULT (datetime(\'now\'))
+        )');
+
+        $this->pdo->exec('CREATE TABLE award_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            painting_id INTEGER NOT NULL,
+            user_id INTEGER NOT NULL,
+            awarded_by INTEGER NOT NULL,
+            action TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime(\'now\')),
+            FOREIGN KEY (painting_id) REFERENCES paintings(id),
+            FOREIGN KEY (user_id) REFERENCES users(id),
+            FOREIGN KEY (awarded_by) REFERENCES users(id)
+        )');
+
+        $this->db = new Database($this->pdo);
+        return $this->db;
+    }
+
+    /** Insert a user and return the ID. */
+    private function insertUser(string $email, string $name = '', bool $isAdmin = false, ?string $passwordHash = null): int
+    {
+        $this->db->execute(
+            'INSERT INTO users (email, name, is_admin, password_hash) VALUES (:e, :n, :a, :p)',
+            [':e' => $email, ':n' => $name, ':a' => $isAdmin ? 1 : 0, ':p' => $passwordHash]
+        );
+        return $this->db->lastInsertId();
+    }
+
+    /** Insert a painting and return the ID. */
+    private function insertPainting(string $title, ?int $awardedTo = null, string $description = '', string $createdAt = ''): int
+    {
+        $at = $createdAt ?: date('Y-m-d H:i:s');
+        $this->db->execute(
+            'INSERT INTO paintings (title, description, filename, original_filename, awarded_to, created_at)
+             VALUES (:t, :d, :f, :of, :aw, :ca)',
+            [
+                ':t' => $title,
+                ':d' => $description,
+                ':f' => 'img_' . bin2hex(random_bytes(4)) . '.jpg',
+                ':of' => $title . '.jpg',
+                ':aw' => $awardedTo,
+                ':ca' => $at,
+            ]
+        );
+        return $this->db->lastInsertId();
+    }
+
+    /** Insert an interest and return the ID. */
+    private function insertInterest(int $paintingId, int $userId, string $message = '', string $createdAt = ''): int
+    {
+        $at = $createdAt ?: date('Y-m-d H:i:s');
+        $this->db->execute(
+            'INSERT INTO interests (painting_id, user_id, message, created_at) VALUES (:p, :u, :m, :c)',
+            [':p' => $paintingId, ':u' => $userId, ':m' => $message, ':c' => $at]
+        );
+        return $this->db->lastInsertId();
+    }
+
+    /** Insert a site setting. */
+    private function insertSetting(string $key, string $value): void
+    {
+        $this->db->execute(
+            'INSERT INTO site_settings (setting_key, setting_value) VALUES (:k, :v)',
+            [':k' => $key, ':v' => $value]
+        );
+    }
+}

--- a/tests/Controllers/GalleryControllerTest.php
+++ b/tests/Controllers/GalleryControllerTest.php
@@ -1,0 +1,362 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests\Controllers;
+
+use Heirloom\Database;
+use Heirloom\SiteSettings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the database queries used by GalleryController.
+ *
+ * We cannot call the controller methods directly because they invoke
+ * header()/exit() or Template::render(), so we exercise the exact SQL
+ * the controller relies on against an in-memory SQLite database.
+ */
+class GalleryControllerTest extends TestCase
+{
+    use ControllerTestSchema;
+
+    private SiteSettings $settings;
+
+    protected function setUp(): void
+    {
+        $this->createDatabase();
+        $this->settings = new SiteSettings($this->db);
+    }
+
+    // ---------------------------------------------------------------
+    // Gallery index: total count of available paintings
+    // ---------------------------------------------------------------
+
+    public function testCountAvailablePaintingsExcludesAwarded(): void
+    {
+        $user = $this->insertUser('u@test.com');
+        $this->insertPainting('Available 1');
+        $this->insertPainting('Available 2');
+        $this->insertPainting('Awarded', $user);
+
+        $total = (int) $this->db->scalar(
+            'SELECT COUNT(*) FROM paintings WHERE awarded_to IS NULL'
+        );
+
+        $this->assertSame(2, $total);
+    }
+
+    public function testCountAvailablePaintingsReturnsZeroWhenEmpty(): void
+    {
+        $total = (int) $this->db->scalar(
+            'SELECT COUNT(*) FROM paintings WHERE awarded_to IS NULL'
+        );
+
+        $this->assertSame(0, $total);
+    }
+
+    // ---------------------------------------------------------------
+    // Pagination math (mirrors GalleryController::index logic)
+    // ---------------------------------------------------------------
+
+    public function testPaginationMathFirstPage(): void
+    {
+        $perPage = 3;
+        for ($i = 1; $i <= 7; $i++) {
+            $this->insertPainting("Painting $i");
+        }
+
+        $total = (int) $this->db->scalar('SELECT COUNT(*) FROM paintings WHERE awarded_to IS NULL');
+        $totalPages = max(1, (int) ceil($total / $perPage));
+        $page = min(1, $totalPages);
+        $offset = ($page - 1) * $perPage;
+
+        $this->assertSame(7, $total);
+        $this->assertSame(3, $totalPages);
+        $this->assertSame(1, $page);
+        $this->assertSame(0, $offset);
+    }
+
+    public function testPaginationMathLastPage(): void
+    {
+        $perPage = 3;
+        for ($i = 1; $i <= 7; $i++) {
+            $this->insertPainting("Painting $i");
+        }
+
+        $total = (int) $this->db->scalar('SELECT COUNT(*) FROM paintings WHERE awarded_to IS NULL');
+        $totalPages = max(1, (int) ceil($total / $perPage));
+        $requestedPage = 10;
+        $page = min($requestedPage, $totalPages);
+        $offset = ($page - 1) * $perPage;
+
+        $this->assertSame(3, $page);
+        $this->assertSame(6, $offset);
+    }
+
+    public function testPaginationWithZeroPaintingsGivesOnePage(): void
+    {
+        $perPage = 12;
+        $total = (int) $this->db->scalar('SELECT COUNT(*) FROM paintings WHERE awarded_to IS NULL');
+        $totalPages = max(1, (int) ceil($total / $perPage));
+
+        $this->assertSame(0, $total);
+        $this->assertSame(1, $totalPages);
+    }
+
+    // ---------------------------------------------------------------
+    // Gallery index: paintings query with interest count
+    // ---------------------------------------------------------------
+
+    public function testGalleryQueryReturnsInterestCount(): void
+    {
+        $u1 = $this->insertUser('a@test.com');
+        $u2 = $this->insertUser('b@test.com');
+
+        $p1 = $this->insertPainting('P1');
+        $p2 = $this->insertPainting('P2');
+
+        $this->insertInterest($p1, $u1);
+        $this->insertInterest($p1, $u2);
+        $this->insertInterest($p2, $u1);
+
+        $paintings = $this->db->fetchAll(
+            'SELECT p.*, (SELECT COUNT(*) FROM interests i WHERE i.painting_id = p.id) AS interest_count
+             FROM paintings p
+             WHERE p.awarded_to IS NULL
+             ORDER BY p.created_at DESC
+             LIMIT :limit OFFSET :offset',
+            [':limit' => 10, ':offset' => 0]
+        );
+
+        $this->assertCount(2, $paintings);
+        // Most recently created first
+        $byTitle = [];
+        foreach ($paintings as $p) {
+            $byTitle[$p['title']] = (int) $p['interest_count'];
+        }
+        $this->assertSame(2, $byTitle['P1']);
+        $this->assertSame(1, $byTitle['P2']);
+    }
+
+    public function testGalleryQueryExcludesAwardedPaintings(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $this->insertPainting('Available');
+        $this->insertPainting('Gone', $u);
+
+        $paintings = $this->db->fetchAll(
+            'SELECT p.*, (SELECT COUNT(*) FROM interests i WHERE i.painting_id = p.id) AS interest_count
+             FROM paintings p
+             WHERE p.awarded_to IS NULL
+             ORDER BY p.created_at DESC
+             LIMIT :limit OFFSET :offset',
+            [':limit' => 10, ':offset' => 0]
+        );
+
+        $this->assertCount(1, $paintings);
+        $this->assertSame('Available', $paintings[0]['title']);
+    }
+
+    public function testGalleryQueryRespectsLimitAndOffset(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->insertPainting("P$i", null, '', "2025-01-0$i 00:00:00");
+        }
+
+        $paintings = $this->db->fetchAll(
+            'SELECT p.*, (SELECT COUNT(*) FROM interests i WHERE i.painting_id = p.id) AS interest_count
+             FROM paintings p
+             WHERE p.awarded_to IS NULL
+             ORDER BY p.created_at DESC
+             LIMIT :limit OFFSET :offset',
+            [':limit' => 2, ':offset' => 2]
+        );
+
+        $this->assertCount(2, $paintings);
+        // Ordered by created_at DESC: P5, P4, P3, P2, P1 — offset 2 => P3, P2
+        $this->assertSame('P3', $paintings[0]['title']);
+        $this->assertSame('P2', $paintings[1]['title']);
+    }
+
+    // ---------------------------------------------------------------
+    // User interests lookup
+    // ---------------------------------------------------------------
+
+    public function testUserInterestsLookup(): void
+    {
+        $u1 = $this->insertUser('user@test.com');
+        $u2 = $this->insertUser('other@test.com');
+
+        $p1 = $this->insertPainting('A');
+        $p2 = $this->insertPainting('B');
+        $p3 = $this->insertPainting('C');
+
+        $this->insertInterest($p1, $u1);
+        $this->insertInterest($p3, $u1);
+        $this->insertInterest($p2, $u2);
+
+        $rows = $this->db->fetchAll(
+            'SELECT painting_id FROM interests WHERE user_id = :uid',
+            [':uid' => $u1]
+        );
+
+        $userInterests = [];
+        foreach ($rows as $row) {
+            $userInterests[$row['painting_id']] = true;
+        }
+
+        $this->assertArrayHasKey($p1, $userInterests);
+        $this->assertArrayHasKey($p3, $userInterests);
+        $this->assertArrayNotHasKey($p2, $userInterests);
+    }
+
+    // ---------------------------------------------------------------
+    // Show painting: single painting queries
+    // ---------------------------------------------------------------
+
+    public function testShowPaintingQueryReturnsRow(): void
+    {
+        $id = $this->insertPainting('Test Painting', null, 'A lovely piece');
+
+        $painting = $this->db->fetchOne(
+            'SELECT * FROM paintings WHERE id = :id',
+            [':id' => $id]
+        );
+
+        $this->assertNotNull($painting);
+        $this->assertSame('Test Painting', $painting['title']);
+        $this->assertSame('A lovely piece', $painting['description']);
+    }
+
+    public function testShowPaintingQueryReturnsNullForMissing(): void
+    {
+        $painting = $this->db->fetchOne(
+            'SELECT * FROM paintings WHERE id = :id',
+            [':id' => 999]
+        );
+
+        $this->assertNull($painting);
+    }
+
+    public function testShowPaintingInterestCheck(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $p = $this->insertPainting('P');
+        $this->insertInterest($p, $u);
+
+        $hasInterest = (bool) $this->db->fetchOne(
+            'SELECT 1 FROM interests WHERE painting_id = :pid AND user_id = :uid',
+            [':pid' => $p, ':uid' => $u]
+        );
+
+        $this->assertTrue($hasInterest);
+    }
+
+    public function testShowPaintingInterestCheckReturnsFalseWhenNone(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $p = $this->insertPainting('P');
+
+        $hasInterest = (bool) $this->db->fetchOne(
+            'SELECT 1 FROM interests WHERE painting_id = :pid AND user_id = :uid',
+            [':pid' => $p, ':uid' => $u]
+        );
+
+        $this->assertFalse($hasInterest);
+    }
+
+    public function testShowPaintingInterestCountQuery(): void
+    {
+        $u1 = $this->insertUser('a@test.com');
+        $u2 = $this->insertUser('b@test.com');
+        $p = $this->insertPainting('P');
+
+        $this->insertInterest($p, $u1);
+        $this->insertInterest($p, $u2);
+
+        $count = (int) $this->db->scalar(
+            'SELECT COUNT(*) FROM interests WHERE painting_id = :pid',
+            [':pid' => $p]
+        );
+
+        $this->assertSame(2, $count);
+    }
+
+    // ---------------------------------------------------------------
+    // Express interest: toggle logic (insert / delete)
+    // ---------------------------------------------------------------
+
+    public function testExpressInterestInsertsNewInterest(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $p = $this->insertPainting('P');
+
+        // No existing interest — insert
+        $existing = $this->db->fetchOne(
+            'SELECT 1 FROM interests WHERE painting_id = :pid AND user_id = :uid',
+            [':pid' => $p, ':uid' => $u]
+        );
+        $this->assertNull($existing);
+
+        $this->db->execute(
+            'INSERT INTO interests (painting_id, user_id, message) VALUES (:pid, :uid, :msg)',
+            [':pid' => $p, ':uid' => $u, ':msg' => 'I love it']
+        );
+
+        $interest = $this->db->fetchOne(
+            'SELECT * FROM interests WHERE painting_id = :pid AND user_id = :uid',
+            [':pid' => $p, ':uid' => $u]
+        );
+        $this->assertNotNull($interest);
+        $this->assertSame('I love it', $interest['message']);
+    }
+
+    public function testExpressInterestTogglesOffExisting(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $p = $this->insertPainting('P');
+        $this->insertInterest($p, $u);
+
+        // Existing interest found — delete
+        $this->db->execute(
+            'DELETE FROM interests WHERE painting_id = :pid AND user_id = :uid',
+            [':pid' => $p, ':uid' => $u]
+        );
+
+        $remaining = $this->db->fetchOne(
+            'SELECT 1 FROM interests WHERE painting_id = :pid AND user_id = :uid',
+            [':pid' => $p, ':uid' => $u]
+        );
+        $this->assertNull($remaining);
+    }
+
+    public function testExpressInterestOnlyAffectsAvailablePaintings(): void
+    {
+        $u = $this->insertUser('u@test.com');
+        $pAwarded = $this->insertPainting('Awarded', $u);
+
+        $painting = $this->db->fetchOne(
+            'SELECT * FROM paintings WHERE id = :id AND awarded_to IS NULL',
+            [':id' => $pAwarded]
+        );
+
+        $this->assertNull($painting, 'Awarded painting should not be returned for interest expression');
+    }
+
+    // ---------------------------------------------------------------
+    // Gallery per-page setting
+    // ---------------------------------------------------------------
+
+    public function testGalleryPerPageSetting(): void
+    {
+        $this->insertSetting('gallery_per_page', '6');
+
+        $perPage = $this->settings->getInt('gallery_per_page', 12);
+        $this->assertSame(6, $perPage);
+    }
+
+    public function testGalleryPerPageSettingDefaultsTo12(): void
+    {
+        $perPage = $this->settings->getInt('gallery_per_page', 12);
+        $this->assertSame(12, $perPage);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds integration tests for all three controllers (GalleryController, AdminController, AuthController) using in-memory SQLite
- Tests the actual SQL queries and business logic controllers depend on, without calling header()/exit()
- Includes a shared `ControllerTestSchema` trait that sets up the full DB schema (users, paintings, interests, magic_links, site_settings, login_attempts, award_log)

Covers:
- **GalleryController**: pagination math, interest count subqueries, user interest lookups, LIMIT/OFFSET, interest toggle (insert/delete)
- **AdminController**: dashboard filters (available/awarded/wanted/all), sort column whitelist, sort direction safety, interest count + last_interest_at queries, award/unassign DB changes + log entries, edit/delete/tracking updates, upload row insertion, multi-file title generation
- **AuthController**: email normalization, rate limiter (record/check/clear/isolate), password login (success/fail/no-hash), find/create user, magic link creation, password updates, profile awarded-paintings query, shipping address updates, registration settings, redirect safety

Closes #26

## Test plan
- [x] `composer check` passes (211 tests, 337 assertions, 29 specs)
- [x] No src/ files modified

Generated with [Claude Code](https://claude.com/claude-code)