### PR TITLE
Add cache headers for static assets

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -2,3 +2,22 @@ RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^ index.php [QSA,L]
+
+# Cache static assets
+<IfModule mod_expires.c>
+    ExpiresActive On
+    ExpiresByType text/css "access plus 1 week"
+    ExpiresByType image/jpeg "access plus 1 month"
+    ExpiresByType image/png "access plus 1 month"
+    ExpiresByType image/gif "access plus 1 month"
+    ExpiresByType image/webp "access plus 1 month"
+</IfModule>
+
+<IfModule mod_headers.c>
+    <FilesMatch "\.(css)$">
+        Header set Cache-Control "max-age=604800, public"
+    </FilesMatch>
+    <FilesMatch "\.(jpg|jpeg|png|gif|webp)$">
+        Header set Cache-Control "max-age=2592000, public"
+    </FilesMatch>
+</IfModule>

--- a/templates/layout.php
+++ b/templates/layout.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= \Heirloom\Template::escape($siteName) ?></title>
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/css/style.css?v=1">
 </head>
 <body>
     <nav class="navbar">


### PR DESCRIPTION
## Summary
- Add `mod_expires` and `mod_headers` cache rules to `public/.htaccess`: CSS cached for 1 week, images (jpg, jpeg, png, gif, webp) cached for 1 month
- Add cache-busting version query param to CSS link in `templates/layout.php` (`style.css?v=1`)

Closes #43

## Test plan
- [ ] Verify Apache serves `Cache-Control` headers for CSS and image files
- [ ] Confirm CSS link in page source includes `?v=1` query string
- [ ] Check that `composer check` passes (tests + specs green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)