### PR TITLE
Add session timeout and idle detection

### DIFF
--- a/migrate.php
+++ b/migrate.php
@@ -136,6 +136,7 @@ $defaults = [
     ['admin_per_page', '20', 'Admin Items Per Page', 'Number of paintings shown per page in the admin dashboard.'],
     ['registration_open', '1', 'Registration Open', 'Set to 0 to disable new user registration.'],
     ['contact_email', '', 'Contact Email', 'Shown to users who need to reach the site owner. Leave blank to hide.'],
+    ['session_timeout_minutes', '120', 'Session Timeout (minutes)', 'Idle sessions are automatically logged out after this many minutes of inactivity.'],
 ];
 foreach ($defaults as [$key, $value, $label, $desc]) {
     $stmt = $pdo->prepare('SELECT 1 FROM site_settings WHERE setting_key = :k');

--- a/public/index.php
+++ b/public/index.php
@@ -39,6 +39,9 @@ if ($mailHost) {
 } else {
     $auth->setMailer(new LogMailer());
 }
+$auth->checkSessionTimeout();
+$auth->touchActivity();
+
 $router = new Router();
 
 $gallery = new GalleryController($db, $auth, $settings);

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -105,6 +105,49 @@ class Auth
         session_destroy();
     }
 
+    private function sessionTimeoutMinutes(): int
+    {
+        return $this->settings ? $this->settings->getInt('session_timeout_minutes', 120) : 120;
+    }
+
+    /**
+     * Check whether the current session has expired due to inactivity.
+     * Returns true if the session is expired, false otherwise.
+     */
+    public function isSessionExpired(): bool
+    {
+        if (!$this->isLoggedIn()) {
+            return false;
+        }
+        if (!isset($_SESSION['last_activity'])) {
+            return false;
+        }
+        $timeout = $this->sessionTimeoutMinutes() * 60;
+        return (time() - (int) $_SESSION['last_activity']) > $timeout;
+    }
+
+    /**
+     * If the session has timed out, log out and redirect to /login.
+     */
+    public function checkSessionTimeout(): void
+    {
+        if ($this->isSessionExpired()) {
+            $this->logout();
+            session_start();
+            $_SESSION['flash_message'] = 'Your session has expired due to inactivity. Please log in again.';
+            header('Location: /login');
+            exit;
+        }
+    }
+
+    /**
+     * Record current time as last activity for session timeout tracking.
+     */
+    public function touchActivity(): void
+    {
+        $_SESSION['last_activity'] = time();
+    }
+
     public static function normalizeEmail(string $email): string
     {
         return strtolower(trim($email));

--- a/tests/SessionTimeoutTest.php
+++ b/tests/SessionTimeoutTest.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Auth;
+use Heirloom\Database;
+use Heirloom\SiteSettings;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class SessionTimeoutTest extends TestCase
+{
+    private Auth $auth;
+    private Database $db;
+    private SiteSettings $settings;
+
+    protected function setUp(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        $pdo->exec("
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT UNIQUE NOT NULL,
+                name TEXT NOT NULL DEFAULT '',
+                password_hash TEXT,
+                is_admin INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+        ");
+        $pdo->exec("
+            CREATE TABLE magic_links (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL,
+                token TEXT UNIQUE NOT NULL,
+                used INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+        ");
+        $pdo->exec("
+            CREATE TABLE site_settings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                setting_key TEXT UNIQUE NOT NULL,
+                setting_value TEXT NOT NULL DEFAULT ''
+            )
+        ");
+
+        $this->db = new Database($pdo);
+        $this->settings = new SiteSettings($this->db);
+        $this->auth = new Auth($this->db);
+        $this->auth->setSettings($this->settings);
+
+        if (!isset($_SESSION)) {
+            $_SESSION = [];
+        }
+        unset($_SESSION['user_id'], $_SESSION['last_activity']);
+    }
+
+    // --- checkSessionTimeout ---
+
+    public function testCheckSessionTimeoutReturnsFalseWhenNoLastActivity(): void
+    {
+        $_SESSION['user_id'] = 1;
+        // No last_activity set
+        $this->assertFalse($this->auth->isSessionExpired());
+    }
+
+    public function testCheckSessionTimeoutReturnsTrueWhenActivityIsRecent(): void
+    {
+        $_SESSION['user_id'] = 1;
+        $_SESSION['last_activity'] = time() - 60; // 1 minute ago
+        $this->assertFalse($this->auth->isSessionExpired());
+    }
+
+    public function testCheckSessionTimeoutReturnsFalseWhenExpired(): void
+    {
+        $_SESSION['user_id'] = 1;
+        $this->settings->set('session_timeout_minutes', '120');
+        $_SESSION['last_activity'] = time() - (121 * 60); // 121 minutes ago
+        $this->assertTrue($this->auth->isSessionExpired());
+    }
+
+    // --- touchActivity ---
+
+    public function testTouchActivitySetsLastActivity(): void
+    {
+        $before = time();
+        $this->auth->touchActivity();
+        $after = time();
+
+        $this->assertArrayHasKey('last_activity', $_SESSION);
+        $this->assertGreaterThanOrEqual($before, $_SESSION['last_activity']);
+        $this->assertLessThanOrEqual($after, $_SESSION['last_activity']);
+    }
+
+    // --- timeout respects setting ---
+
+    public function testSessionTimeoutUsesDefaultOf120Minutes(): void
+    {
+        $_SESSION['user_id'] = 1;
+        // Default is 120 minutes; 119 minutes ago should NOT be expired
+        $_SESSION['last_activity'] = time() - (119 * 60);
+        $this->assertFalse($this->auth->isSessionExpired());
+    }
+
+    public function testSessionTimeoutUsesCustomSetting(): void
+    {
+        $_SESSION['user_id'] = 1;
+        $this->settings->set('session_timeout_minutes', '30');
+        $_SESSION['last_activity'] = time() - (31 * 60); // 31 minutes ago
+        $this->assertTrue($this->auth->isSessionExpired());
+    }
+
+    public function testSessionTimeoutCustomSettingNotExpired(): void
+    {
+        $_SESSION['user_id'] = 1;
+        $this->settings->set('session_timeout_minutes', '30');
+        $_SESSION['last_activity'] = time() - (29 * 60); // 29 minutes ago
+        $this->assertFalse($this->auth->isSessionExpired());
+    }
+
+    public function testCheckSessionTimeoutReturnsFalseWhenNotLoggedIn(): void
+    {
+        // No user_id in session
+        $this->assertFalse($this->auth->isSessionExpired());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `session_timeout_minutes` site setting (default 120 minutes) to control idle session expiry
- Adds `checkSessionTimeout()` and `touchActivity()` methods to `Auth` class; expired sessions are logged out and redirected to `/login` with a flash message
- Hooks timeout check and activity touch into `public/index.php` on every request
- Adds 8 unit tests in `SessionTimeoutTest.php` covering expiry, recent activity, no-activity, custom settings, and not-logged-in cases

Closes #42

## Test plan
- [x] `composer check` passes (232 tests, 29 specs)
- [ ] Verify idle session is logged out after configured timeout
- [ ] Verify flash message appears on /login after timeout
- [ ] Verify `session_timeout_minutes` setting is editable in admin

Generated with [Claude Code](https://claude.com/claude-code)