### PR TITLE
Add styled error pages (404, 403, 500) — closes #39

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -18,6 +18,16 @@ use Heirloom\Controllers\AdminController;
 
 Config::load(__DIR__ . '/../.env');
 
+set_exception_handler(function (\Throwable $e): void {
+    error_log($e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
+    http_response_code(500);
+    Template::render('error', [
+        'code' => 500,
+        'message' => 'An unexpected error occurred. Please try again later.',
+        'noLayout' => true,
+    ]);
+});
+
 session_start();
 
 $db = Database::getInstance();
@@ -82,7 +92,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $token = $_POST['_csrf_token'] ?? '';
     if (!Csrf::validate($token)) {
         http_response_code(403);
-        echo '<h1>403 Forbidden</h1><p>Invalid or missing CSRF token. Please go back and try again.</p>';
+        Template::render('error', [
+            'code' => 403,
+            'message' => 'Invalid or missing CSRF token. Please go back and try again.',
+            'noLayout' => true,
+        ]);
         exit;
     }
 }

--- a/src/Router.php
+++ b/src/Router.php
@@ -33,6 +33,10 @@ class Router
         }
 
         http_response_code(404);
-        echo '<h1>404 Not Found</h1>';
+        Template::render('error', [
+            'code' => 404,
+            'message' => 'The page you requested could not be found.',
+            'noLayout' => true,
+        ]);
     }
 }

--- a/templates/error.php
+++ b/templates/error.php
@@ -1,0 +1,5 @@
+<div class="error-page">
+    <h1><?= \Heirloom\Template::escape((string) $code) ?></h1>
+    <p><?= \Heirloom\Template::escape($message) ?></p>
+    <a href="/" class="btn">Back to Gallery</a>
+</div>

--- a/tests/ErrorPageTest.php
+++ b/tests/ErrorPageTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Template;
+use PHPUnit\Framework\TestCase;
+
+class ErrorPageTest extends TestCase
+{
+    public function testRenderErrorTemplateWithNoLayout(): void
+    {
+        ob_start();
+        Template::render('error', [
+            'code' => 404,
+            'message' => 'The page you requested could not be found.',
+            'noLayout' => true,
+        ]);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('404', $output);
+        $this->assertStringContainsString('The page you requested could not be found.', $output);
+        $this->assertStringContainsString('Back to Gallery', $output);
+        // noLayout means no <!DOCTYPE html> wrapper
+        $this->assertStringNotContainsString('<!DOCTYPE html>', $output);
+    }
+
+    public function testRenderError403(): void
+    {
+        ob_start();
+        Template::render('error', [
+            'code' => 403,
+            'message' => 'Forbidden',
+            'noLayout' => true,
+        ]);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('403', $output);
+        $this->assertStringContainsString('Forbidden', $output);
+    }
+
+    public function testRenderError500(): void
+    {
+        ob_start();
+        Template::render('error', [
+            'code' => 500,
+            'message' => 'An unexpected error occurred. Please try again later.',
+            'noLayout' => true,
+        ]);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('500', $output);
+        $this->assertStringContainsString('An unexpected error occurred.', $output);
+    }
+
+    public function testErrorTemplateEscapesHtml(): void
+    {
+        ob_start();
+        Template::render('error', [
+            'code' => 400,
+            'message' => '<script>alert("xss")</script>',
+            'noLayout' => true,
+        ]);
+        $output = ob_get_clean();
+
+        $this->assertStringNotContainsString('<script>', $output);
+        $this->assertStringContainsString('&lt;script&gt;', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- New error.php template with styled layout, error code, message, and back-to-gallery link
- Router 404, CSRF 403, and unhandled exceptions (500) all use the template
- set_exception_handler logs errors and shows user-friendly 500 page (no stack trace)
- 4 new tests

Closes #39