### PR TITLE
Add gallery search and sorting for users

### DIFF
--- a/src/Controllers/GalleryController.php
+++ b/src/Controllers/GalleryController.php
@@ -16,21 +16,39 @@ class GalleryController
     {
         $perPage = $this->settings->getInt('gallery_per_page', 12);
         $page = max(1, (int) ($_GET['page'] ?? 1));
+        $search = trim($_GET['q'] ?? '');
+        $sort = $_GET['sort'] ?? 'newest';
+
+        // Build WHERE clause
+        $where = 'p.awarded_to IS NULL';
+        $params = [];
+        if ($search !== '') {
+            $where .= ' AND (p.title LIKE :search OR p.description LIKE :search)';
+            $params[':search'] = '%' . $search . '%';
+        }
 
         $total = (int) $this->db->scalar(
-            'SELECT COUNT(*) FROM paintings WHERE awarded_to IS NULL'
+            "SELECT COUNT(*) FROM paintings p WHERE $where",
+            $params
         );
         $totalPages = max(1, (int) ceil($total / $perPage));
         $page = min($page, $totalPages);
         $offset = ($page - 1) * $perPage;
 
+        // Determine ORDER BY
+        $orderBy = match ($sort) {
+            'wanted' => 'interest_count DESC',
+            'title'  => 'p.title ASC',
+            default  => 'p.created_at DESC',
+        };
+
         $paintings = $this->db->fetchAll(
-            'SELECT p.*, (SELECT COUNT(*) FROM interests i WHERE i.painting_id = p.id) AS interest_count
+            "SELECT p.*, (SELECT COUNT(*) FROM interests i WHERE i.painting_id = p.id) AS interest_count
              FROM paintings p
-             WHERE p.awarded_to IS NULL
-             ORDER BY p.created_at DESC
-             LIMIT :limit OFFSET :offset',
-            [':limit' => $perPage, ':offset' => $offset]
+             WHERE $where
+             ORDER BY $orderBy
+             LIMIT :limit OFFSET :offset",
+            $params + [':limit' => $perPage, ':offset' => $offset]
         );
 
         // Check which ones current user has expressed interest in
@@ -52,6 +70,8 @@ class GalleryController
             'total' => $total,
             'userInterests' => $userInterests,
             'auth' => $this->auth,
+            'search' => $search,
+            'sort' => $sort,
         ]);
     }
 

--- a/templates/gallery.php
+++ b/templates/gallery.php
@@ -1,10 +1,33 @@
 <?php use Heirloom\Template;
-use Heirloom\Thumbnail; ?>
+use Heirloom\Thumbnail;
+
+$paginationParams = [];
+if ($search !== '') {
+    $paginationParams['q'] = $search;
+}
+if ($sort !== 'newest') {
+    $paginationParams['sort'] = $sort;
+}
+?>
 
 <div class="gallery-header">
     <h1>Paintings Available</h1>
     <p><?= $total ?> painting<?= $total !== 1 ? 's' : '' ?> looking for a new home</p>
 </div>
+
+<form method="get" action="/gallery" class="gallery-search-form">
+    <input type="text"
+           name="q"
+           value="<?= Template::escape($search) ?>"
+           placeholder="Search by title or description..."
+           aria-label="Search paintings">
+    <select name="sort" aria-label="Sort paintings">
+        <option value="newest"<?= $sort === 'newest' ? ' selected' : '' ?>>Newest first</option>
+        <option value="wanted"<?= $sort === 'wanted' ? ' selected' : '' ?>>Most wanted</option>
+        <option value="title"<?= $sort === 'title' ? ' selected' : '' ?>>Title A-Z</option>
+    </select>
+    <button type="submit">Search</button>
+</form>
 
 <?php if (empty($paintings)): ?>
     <p>No paintings available right now. Check back soon!</p>
@@ -32,9 +55,14 @@ use Heirloom\Thumbnail; ?>
     </div>
 
     <?php if ($totalPages > 1): ?>
+        <?php
+        $pageUrl = function (int $p) use ($paginationParams): string {
+            return '?' . http_build_query(array_merge($paginationParams, ['page' => $p]));
+        };
+        ?>
         <div class="pagination">
             <?php if ($page > 1): ?>
-                <a href="?page=<?= $page - 1 ?>">&laquo; Prev</a>
+                <a href="<?= $pageUrl($page - 1) ?>">&laquo; Prev</a>
             <?php else: ?>
                 <span class="disabled">&laquo; Prev</span>
             <?php endif; ?>
@@ -43,7 +71,7 @@ use Heirloom\Thumbnail; ?>
             $start = max(1, $page - 2);
             $end = min($totalPages, $page + 2);
             if ($start > 1): ?>
-                <a href="?page=1">1</a>
+                <a href="<?= $pageUrl(1) ?>">1</a>
                 <?php if ($start > 2): ?><span>...</span><?php endif; ?>
             <?php endif; ?>
 
@@ -51,17 +79,17 @@ use Heirloom\Thumbnail; ?>
                 <?php if ($i === $page): ?>
                     <span class="current"><?= $i ?></span>
                 <?php else: ?>
-                    <a href="?page=<?= $i ?>"><?= $i ?></a>
+                    <a href="<?= $pageUrl($i) ?>"><?= $i ?></a>
                 <?php endif; ?>
             <?php endfor; ?>
 
             <?php if ($end < $totalPages): ?>
                 <?php if ($end < $totalPages - 1): ?><span>...</span><?php endif; ?>
-                <a href="?page=<?= $totalPages ?>"><?= $totalPages ?></a>
+                <a href="<?= $pageUrl($totalPages) ?>"><?= $totalPages ?></a>
             <?php endif; ?>
 
             <?php if ($page < $totalPages): ?>
-                <a href="?page=<?= $page + 1 ?>">Next &raquo;</a>
+                <a href="<?= $pageUrl($page + 1) ?>">Next &raquo;</a>
             <?php else: ?>
                 <span class="disabled">Next &raquo;</span>
             <?php endif; ?>

--- a/tests/GallerySearchTest.php
+++ b/tests/GallerySearchTest.php
@@ -1,0 +1,190 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Auth;
+use Heirloom\Controllers\GalleryController;
+use Heirloom\Database;
+use Heirloom\SiteSettings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for gallery search and sorting (issue #40).
+ *
+ * Because Template::render() requires the filesystem and outputs HTML,
+ * we test the controller indirectly by verifying that the Database
+ * receives the correct SQL queries (LIKE clauses, ORDER BY, LIMIT/OFFSET).
+ */
+class GallerySearchTest extends TestCase
+{
+    private Database $db;
+    private Auth $auth;
+    private SiteSettings $settings;
+
+    protected function setUp(): void
+    {
+        $this->db = $this->createMock(Database::class);
+        $this->auth = $this->createMock(Auth::class);
+        $this->settings = $this->createMock(SiteSettings::class);
+
+        $this->settings->method('getInt')->willReturn(12);
+        $this->auth->method('isLoggedIn')->willReturn(false);
+    }
+
+    // ---------------------------------------------------------------
+    // Search by title LIKE
+    // ---------------------------------------------------------------
+    public function testSearchByTitleLike(): void
+    {
+        $_GET = ['q' => 'sunset', 'page' => '1'];
+
+        // The main query should contain LIKE for title OR description
+        $this->db->expects($this->atLeastOnce())
+            ->method('fetchAll')
+            ->willReturn([]);
+
+        $this->db->expects($this->atLeastOnce())
+            ->method('scalar')
+            ->with(
+                $this->callback(function (string $sql): bool {
+                    return str_contains($sql, 'LIKE') &&
+                           str_contains($sql, 'title') &&
+                           str_contains($sql, 'description');
+                }),
+                $this->callback(function (array $params): bool {
+                    return isset($params[':search']) && $params[':search'] === '%sunset%';
+                })
+            )
+            ->willReturn(0);
+
+        $controller = new GalleryController($this->db, $this->auth, $this->settings);
+
+        ob_start();
+        $controller->index();
+        ob_end_clean();
+    }
+
+    // ---------------------------------------------------------------
+    // Sort by interest_count DESC  (sort=wanted)
+    // ---------------------------------------------------------------
+    public function testSortByInterestCountDesc(): void
+    {
+        $_GET = ['sort' => 'wanted', 'page' => '1'];
+
+        $this->db->method('scalar')->willReturn(0);
+
+        $this->db->expects($this->atLeastOnce())
+            ->method('fetchAll')
+            ->with(
+                $this->callback(function (string $sql): bool {
+                    return str_contains($sql, 'ORDER BY interest_count DESC');
+                }),
+                $this->anything()
+            )
+            ->willReturn([]);
+
+        $controller = new GalleryController($this->db, $this->auth, $this->settings);
+
+        ob_start();
+        $controller->index();
+        ob_end_clean();
+    }
+
+    // ---------------------------------------------------------------
+    // Sort by title ASC  (sort=title)
+    // ---------------------------------------------------------------
+    public function testSortByTitleAsc(): void
+    {
+        $_GET = ['sort' => 'title', 'page' => '1'];
+
+        $this->db->method('scalar')->willReturn(0);
+
+        $this->db->expects($this->atLeastOnce())
+            ->method('fetchAll')
+            ->with(
+                $this->callback(function (string $sql): bool {
+                    return str_contains($sql, 'ORDER BY p.title ASC');
+                }),
+                $this->anything()
+            )
+            ->willReturn([]);
+
+        $controller = new GalleryController($this->db, $this->auth, $this->settings);
+
+        ob_start();
+        $controller->index();
+        ob_end_clean();
+    }
+
+    // ---------------------------------------------------------------
+    // Search with pagination — page 2 should still pass :search
+    // ---------------------------------------------------------------
+    public function testSearchWithPagination(): void
+    {
+        $_GET = ['q' => 'lake', 'page' => '2'];
+
+        // Return a total that gives multiple pages at 12 per page
+        $this->db->method('scalar')
+            ->with(
+                $this->callback(function (string $sql): bool {
+                    return str_contains($sql, 'LIKE');
+                }),
+                $this->callback(function (array $params): bool {
+                    return ($params[':search'] ?? '') === '%lake%';
+                })
+            )
+            ->willReturn(24);
+
+        $this->db->expects($this->atLeastOnce())
+            ->method('fetchAll')
+            ->with(
+                $this->callback(function (string $sql): bool {
+                    return str_contains($sql, 'LIKE') && str_contains($sql, 'LIMIT');
+                }),
+                $this->callback(function (array $params): bool {
+                    // Page 2 with 12 per page → offset 12
+                    return ($params[':search'] ?? '') === '%lake%' &&
+                           ($params[':offset'] ?? -1) === 12;
+                })
+            )
+            ->willReturn([]);
+
+        $controller = new GalleryController($this->db, $this->auth, $this->settings);
+
+        ob_start();
+        $controller->index();
+        ob_end_clean();
+    }
+
+    // ---------------------------------------------------------------
+    // Default sort (newest) when no sort param provided
+    // ---------------------------------------------------------------
+    public function testDefaultSortIsNewest(): void
+    {
+        $_GET = ['page' => '1'];
+
+        $this->db->method('scalar')->willReturn(0);
+
+        $this->db->expects($this->atLeastOnce())
+            ->method('fetchAll')
+            ->with(
+                $this->callback(function (string $sql): bool {
+                    return str_contains($sql, 'ORDER BY p.created_at DESC');
+                }),
+                $this->anything()
+            )
+            ->willReturn([]);
+
+        $controller = new GalleryController($this->db, $this->auth, $this->settings);
+
+        ob_start();
+        $controller->index();
+        ob_end_clean();
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = [];
+    }
+}


### PR DESCRIPTION
## Summary
- Adds search-by-title/description (`?q=`) and sort (`?sort=newest|wanted|title`) to the gallery index
- Search form with sort dropdown rendered above the gallery grid
- Pagination links preserve `q` and `sort` query parameters
- 5 new PHPUnit tests covering search LIKE, sort variants, pagination with search, and default sort

Closes #40

## Test plan
- [x] `composer check` passes (229 tests, 29 specs)
- [ ] Manual: visit `/gallery?q=sunset` and verify filtered results
- [ ] Manual: select "Most wanted" sort, confirm ORDER BY interest_count DESC
- [ ] Manual: search + paginate, confirm params persist in page links

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>