### PR TITLE
Add password reset via magic link — closes #41

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -67,6 +67,12 @@ class AuthController
             exit;
         }
 
+        // If the user explicitly requested "forgot password", set a session flag
+        // so that after magic link login they are redirected to /set-password.
+        if (!empty($_POST['forgot_password'])) {
+            $_SESSION['forgot_password'] = true;
+        }
+
         $this->rateLimiter->record($identifier);
         $token = $this->auth->createMagicLink($email);
         $sent = $this->auth->sendMagicLink($email, $token);
@@ -157,8 +163,11 @@ class AuthController
         $user = $this->auth->findOrCreateUserByEmail($email);
         $this->auth->loginUser((int) $user['id']);
 
-        // If user has no password, prompt to set one
-        if (!$user['password_hash']) {
+        // If user has no password, or explicitly requested password reset, prompt to set one
+        $forgotPassword = !empty($_SESSION['forgot_password']);
+        unset($_SESSION['forgot_password']);
+
+        if (!$user['password_hash'] || $forgotPassword) {
             header('Location: /set-password');
             exit;
         }

--- a/templates/login.php
+++ b/templates/login.php
@@ -16,6 +16,7 @@
 
         <form method="POST" action="/login">
             <?= \Heirloom\Csrf::hiddenField() ?>
+            <input type="hidden" name="forgot_password" value="1">
             <div class="form-group">
                 <label for="email">Email</label>
                 <input type="email" name="email" id="email" required placeholder="you@example.com">
@@ -28,6 +29,10 @@
 
             <button type="submit" class="btn btn-primary" style="width:100%">Log In</button>
         </form>
+
+        <p style="text-align:center;margin-top:0.75rem;font-size:0.85rem;color:var(--text-muted)">
+            Forgot your password? Leave the password field blank and click Log In to receive a magic link.
+        </p>
 
         <p style="text-align:center;margin-top:1rem;font-size:0.9rem;">
             Don't have an account? <a href="/register">Register</a>

--- a/tests/Controllers/AuthControllerTest.php
+++ b/tests/Controllers/AuthControllerTest.php
@@ -318,6 +318,74 @@ class AuthControllerTest extends TestCase
     }
 
     // ---------------------------------------------------------------
+    // Forgot-password flow: magic link redirects to /set-password
+    // ---------------------------------------------------------------
+
+    public function testMagicLoginRedirectsToSetPasswordWhenUserHasNoPasswordHash(): void
+    {
+        // User with no password_hash should always go to /set-password
+        $uid = $this->insertUser('nopass@test.com', 'No Pass');
+
+        $user = $this->db->fetchOne('SELECT * FROM users WHERE id = :id', [':id' => $uid]);
+        $this->assertNull($user['password_hash']);
+
+        // The magicLogin controller checks !$user['password_hash'] and redirects
+        // to /set-password. This verifies the precondition is correct.
+        $this->assertEmpty($user['password_hash']);
+    }
+
+    public function testForgotPasswordSessionFlagIsSetForUserWithPassword(): void
+    {
+        // When a user with a password explicitly requests forgot-password,
+        // the session flag 'forgot_password' should be set so that after
+        // magic link login they are redirected to /set-password.
+        if (!isset($_SESSION)) {
+            $_SESSION = [];
+        }
+
+        $hash = password_hash('existing123', PASSWORD_DEFAULT);
+        $uid = $this->insertUser('haspass@test.com', 'Has Pass', false, $hash);
+
+        // Simulate the forgot-password flow: POST with forgot_password=1 and empty password
+        // The controller sets $_SESSION['forgot_password'] = true
+        $_SESSION['forgot_password'] = true;
+        $this->assertTrue($_SESSION['forgot_password']);
+
+        // After magic link login, a user WITH a password_hash would normally
+        // go to consumeRedirect(). But with the forgot_password flag, they
+        // should be redirected to /set-password instead.
+        $user = $this->db->fetchOne('SELECT * FROM users WHERE id = :id', [':id' => $uid]);
+        $this->assertNotEmpty($user['password_hash']);
+
+        // The redirect decision: forgot_password flag OR no password_hash
+        $shouldRedirectToSetPassword = !$user['password_hash'] || !empty($_SESSION['forgot_password']);
+        $this->assertTrue($shouldRedirectToSetPassword);
+
+        // Flag should be consumed after use
+        unset($_SESSION['forgot_password']);
+        $this->assertArrayNotHasKey('forgot_password', $_SESSION);
+    }
+
+    public function testMagicLoginDoesNotRedirectToSetPasswordForNormalFlow(): void
+    {
+        // A user WITH a password who logs in via magic link WITHOUT
+        // the forgot-password intent should NOT be redirected to /set-password.
+        if (!isset($_SESSION)) {
+            $_SESSION = [];
+        }
+        unset($_SESSION['forgot_password']);
+
+        $hash = password_hash('existing123', PASSWORD_DEFAULT);
+        $uid = $this->insertUser('normal@test.com', 'Normal', false, $hash);
+
+        $user = $this->db->fetchOne('SELECT * FROM users WHERE id = :id', [':id' => $uid]);
+        $this->assertNotEmpty($user['password_hash']);
+
+        $shouldRedirectToSetPassword = !$user['password_hash'] || !empty($_SESSION['forgot_password']);
+        $this->assertFalse($shouldRedirectToSetPassword);
+    }
+
+    // ---------------------------------------------------------------
     // Redirect safety (mirrors Auth::consumeRedirect logic)
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- "Forgot your password?" UX flow using existing magic link infrastructure
- Hidden `forgot_password` flag triggers redirect to /set-password after magic link login
- Works for users who already have a password (existing flow only redirected users without one)
- 3 new tests

Closes #41