### PR TITLE
Notify losers when a painting is awarded

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -281,4 +281,36 @@ HTML;
             return false;
         }
     }
+
+    public function buildLoserEmail(string $email, string $paintingTitle): EmailMessage
+    {
+        $name = $this->siteName();
+
+        $subject = "Update on a painting you wanted - $name";
+        $htmlBody = <<<HTML
+<h2>Painting Update</h2>
+<p>We wanted to let you know that the painting <strong>$paintingTitle</strong> from $name has been awarded to another recipient.</p>
+<p>Keep an eye on the gallery for more paintings you might love!</p>
+HTML;
+        $textBody = "We wanted to let you know that the painting \"$paintingTitle\" from $name has been awarded to another recipient. Keep an eye on the gallery for more paintings you might love!";
+
+        return new EmailMessage($email, $subject, $htmlBody, $textBody);
+    }
+
+    /**
+     * @param string[] $loserEmails
+     */
+    public function sendLoserNotifications(array $loserEmails, string $paintingTitle): void
+    {
+        $mailer = $this->mailer ?? new LogMailer();
+
+        foreach ($loserEmails as $email) {
+            $message = $this->buildLoserEmail($email, $paintingTitle);
+            try {
+                $mailer->send($message);
+            } catch (\Exception $e) {
+                error_log("Mail error (loser notification to $email): " . $e->getMessage());
+            }
+        }
+    }
 }

--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -270,6 +270,15 @@ class AdminController
             );
             if ($recipient && $painting) {
                 $this->auth->sendAwardNotification($recipient['email'], $painting['title']);
+
+                $losers = $this->db->fetchAll(
+                    'SELECT u.email FROM interests i
+                     JOIN users u ON u.id = i.user_id
+                     WHERE i.painting_id = :pid AND i.user_id != :uid',
+                    [':pid' => (int) $id, ':uid' => $userId]
+                );
+                $loserEmails = array_map(fn(array $row) => $row['email'], $losers);
+                $this->auth->sendLoserNotifications($loserEmails, $painting['title']);
             }
 
             $_SESSION['admin_success'] = 'Painting awarded!';

--- a/tests/LoserNotificationTest.php
+++ b/tests/LoserNotificationTest.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Auth;
+use Heirloom\Database;
+use Heirloom\LogMailer;
+use Heirloom\SiteSettings;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class LoserNotificationTest extends TestCase
+{
+    private Auth $auth;
+    private Database $db;
+    private LogMailer $mailer;
+    private SiteSettings $settings;
+
+    protected function setUp(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        $pdo->exec("CREATE TABLE users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email TEXT UNIQUE NOT NULL,
+            name TEXT NOT NULL DEFAULT '',
+            password_hash TEXT,
+            is_admin INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )");
+        $pdo->exec("CREATE TABLE site_settings (
+            setting_key TEXT PRIMARY KEY,
+            setting_value TEXT NOT NULL DEFAULT '',
+            label TEXT NOT NULL DEFAULT '',
+            description TEXT NOT NULL DEFAULT ''
+        )");
+
+        $this->db = new Database($pdo);
+        $this->settings = new SiteSettings($this->db);
+        $this->mailer = new LogMailer();
+        $this->auth = new Auth($this->db);
+        $this->auth->setSettings($this->settings);
+        $this->auth->setMailer($this->mailer);
+    }
+
+    public function testBuildLoserEmailReturnsEmailMessageWithCorrectRecipient(): void
+    {
+        $msg = $this->auth->buildLoserEmail('alice@example.com', 'Sunset over the Lake');
+        $this->assertSame('alice@example.com', $msg->to);
+    }
+
+    public function testBuildLoserEmailSubjectContainsSiteName(): void
+    {
+        $this->settings->set('site_name', 'Art Giveaway');
+        $msg = $this->auth->buildLoserEmail('bob@example.com', 'Mountain Vista');
+        $this->assertStringContainsString('Art Giveaway', $msg->subject);
+    }
+
+    public function testBuildLoserEmailBodyContainsPaintingTitle(): void
+    {
+        $msg = $this->auth->buildLoserEmail('carol@example.com', 'Sunset over the Lake');
+        $this->assertStringContainsString('Sunset over the Lake', $msg->htmlBody);
+    }
+
+    public function testBuildLoserEmailTextBodyContainsPaintingTitle(): void
+    {
+        $msg = $this->auth->buildLoserEmail('dan@example.com', 'Sunset over the Lake');
+        $this->assertStringContainsString('Sunset over the Lake', $msg->textBody);
+    }
+
+    public function testSendLoserNotificationsEmailsEachLoser(): void
+    {
+        $emails = ['alice@example.com', 'bob@example.com', 'carol@example.com'];
+        $this->auth->sendLoserNotifications($emails, 'Autumn Leaves');
+
+        $messages = $this->mailer->getAllMessages();
+        $this->assertCount(3, $messages);
+
+        $recipients = array_map(fn($m) => $m->to, $messages);
+        $this->assertSame($emails, $recipients);
+
+        foreach ($messages as $msg) {
+            $this->assertStringContainsString('Autumn Leaves', $msg->htmlBody);
+        }
+    }
+
+    public function testSendLoserNotificationsHandlesEmptyArray(): void
+    {
+        $this->auth->sendLoserNotifications([], 'Empty Test');
+
+        $messages = $this->mailer->getAllMessages();
+        $this->assertCount(0, $messages);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `buildLoserEmail()` and `sendLoserNotifications()` to `Auth.php`, following the same pattern as the existing award notification methods
- After awarding a painting in `AdminController::award()`, queries all other interested users and sends each a notification that the painting was awarded to someone else
- Adds `tests/LoserNotificationTest.php` with 6 tests covering email content, multiple recipients, and empty-array edge case

Closes #44

## Test plan
- [x] `composer check` passes (250 tests, 29 specs, 0 failures)
- [ ] Manually award a painting with multiple interested users and verify loser emails are sent
- [ ] Verify the winner still receives their award email
- [ ] Verify unassigning a painting does not trigger loser notifications

Generated with [Claude Code](https://claude.com/claude-code)