### PR TITLE
Add Open Graph meta tags for painting pages

### DIFF
--- a/src/Controllers/GalleryController.php
+++ b/src/Controllers/GalleryController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Heirloom\Controllers;
 
 use Heirloom\Auth;
+use Heirloom\Config;
 use Heirloom\Database;
 use Heirloom\SiteSettings;
 use Heirloom\Template;
@@ -63,6 +64,8 @@ class GalleryController
             }
         }
 
+        Template::setGlobal('ogTitle', $this->settings->get('site_name', SiteSettings::DEFAULT_SITE_NAME));
+
         Template::render('gallery', [
             'paintings' => $paintings,
             'page' => $page,
@@ -99,6 +102,10 @@ class GalleryController
             'SELECT COUNT(*) FROM interests WHERE painting_id = :pid',
             [':pid' => (int) $id]
         );
+
+        Template::setGlobal('ogTitle', $painting['title']);
+        Template::setGlobal('ogDescription', $painting['description'] ?? '');
+        Template::setGlobal('ogImage', Config::get('APP_URL') . '/uploads/' . $painting['filename']);
 
         Template::render('painting', [
             'painting' => $painting,

--- a/src/Template.php
+++ b/src/Template.php
@@ -13,6 +13,11 @@ class Template
         self::$globals[$key] = $value;
     }
 
+    public static function getGlobals(): array
+    {
+        return self::$globals;
+    }
+
     public static function render(string $template, array $data = []): void
     {
         $data = array_merge(self::$globals, $data);

--- a/templates/layout.php
+++ b/templates/layout.php
@@ -4,6 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= \Heirloom\Template::escape($siteName) ?></title>
+    <?php if (!empty($ogTitle)): ?>
+    <meta property="og:title" content="<?= \Heirloom\Template::escape($ogTitle) ?>">
+    <meta property="og:description" content="<?= \Heirloom\Template::escape($ogDescription ?? '') ?>">
+    <meta property="og:image" content="<?= \Heirloom\Template::escape($ogImage ?? '') ?>">
+    <meta property="og:type" content="website">
+    <?php endif; ?>
     <link rel="stylesheet" href="/css/style.css?v=1">
 </head>
 <body>

--- a/tests/OpenGraphTest.php
+++ b/tests/OpenGraphTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Template;
+use PHPUnit\Framework\TestCase;
+
+class OpenGraphTest extends TestCase
+{
+    private \ReflectionProperty $baseProp;
+    private \ReflectionProperty $globalsProp;
+    private string $originalBase;
+    private array $originalGlobals;
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/heirloom_og_' . uniqid();
+        mkdir($this->tmpDir);
+
+        $ref = new \ReflectionClass(Template::class);
+        $this->baseProp = $ref->getProperty('baseDir');
+        $this->globalsProp = $ref->getProperty('globals');
+
+        $this->originalBase = $this->baseProp->getValue();
+        $this->originalGlobals = $this->globalsProp->getValue();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->baseProp->setValue(null, $this->originalBase);
+        $this->globalsProp->setValue(null, $this->originalGlobals);
+
+        foreach (glob($this->tmpDir . '/*.php') as $file) {
+            unlink($file);
+        }
+        rmdir($this->tmpDir);
+    }
+
+    public function testSetGlobalStoresOgValues(): void
+    {
+        $this->globalsProp->setValue(null, []);
+
+        Template::setGlobal('ogTitle', 'Sunset Over Mountains');
+        Template::setGlobal('ogDescription', 'A beautiful landscape painting');
+        Template::setGlobal('ogImage', 'https://example.com/uploads/sunset.jpg');
+
+        $globals = Template::getGlobals();
+
+        $this->assertSame('Sunset Over Mountains', $globals['ogTitle']);
+        $this->assertSame('A beautiful landscape painting', $globals['ogDescription']);
+        $this->assertSame('https://example.com/uploads/sunset.jpg', $globals['ogImage']);
+    }
+
+    public function testOgMetaTagsRenderedInLayout(): void
+    {
+        file_put_contents($this->tmpDir . '/blank.php', '');
+        $layout = <<<'PHP'
+<head>
+<?php if (!empty($ogTitle)): ?>
+<meta property="og:title" content="<?= \Heirloom\Template::escape($ogTitle) ?>">
+<meta property="og:description" content="<?= \Heirloom\Template::escape($ogDescription ?? '') ?>">
+<meta property="og:image" content="<?= \Heirloom\Template::escape($ogImage ?? '') ?>">
+<meta property="og:type" content="website">
+<?php endif; ?>
+</head>
+<?= $content ?>
+PHP;
+        file_put_contents($this->tmpDir . '/layout.php', $layout);
+
+        $this->baseProp->setValue(null, $this->tmpDir);
+        $this->globalsProp->setValue(null, []);
+
+        Template::setGlobal('ogTitle', 'Sunset Over Mountains');
+        Template::setGlobal('ogDescription', 'A beautiful landscape');
+        Template::setGlobal('ogImage', 'https://example.com/uploads/sunset.jpg');
+        Template::setGlobal('siteName', 'Test Gallery');
+
+        ob_start();
+        Template::render('blank', []);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('og:title', $output);
+        $this->assertStringContainsString('Sunset Over Mountains', $output);
+        $this->assertStringContainsString('og:description', $output);
+        $this->assertStringContainsString('A beautiful landscape', $output);
+        $this->assertStringContainsString('og:image', $output);
+        $this->assertStringContainsString('https://example.com/uploads/sunset.jpg', $output);
+        $this->assertStringContainsString('og:type', $output);
+    }
+
+    public function testOgMetaTagsOmittedWhenNoOgTitle(): void
+    {
+        file_put_contents($this->tmpDir . '/blank.php', '');
+        $layout = <<<'PHP'
+<head>
+<?php if (!empty($ogTitle)): ?>
+<meta property="og:title" content="<?= \Heirloom\Template::escape($ogTitle) ?>">
+<?php endif; ?>
+</head>
+<?= $content ?>
+PHP;
+        file_put_contents($this->tmpDir . '/layout.php', $layout);
+
+        $this->baseProp->setValue(null, $this->tmpDir);
+        $this->globalsProp->setValue(null, []);
+        Template::setGlobal('siteName', 'Test Gallery');
+
+        ob_start();
+        Template::render('blank', []);
+        $output = ob_get_clean();
+
+        $this->assertStringNotContainsString('og:title', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `og:title`, `og:description`, `og:image`, and `og:type` meta tags to the layout `<head>` section, conditionally rendered when `ogTitle` is set
- Sets OG globals in `GalleryController::show()` with the painting's title, description, and image URL
- Sets a default `ogTitle` (site name) on the gallery index page
- Adds `Template::getGlobals()` helper for testability
- Adds `OpenGraphTest` with 3 test cases verifying globals storage, meta tag rendering, and conditional omission

Closes #47

## Test plan
- [x] `composer check` passes (247 tests, 29 specs)
- [ ] Verify OG tags appear in page source on a painting detail page
- [ ] Verify OG tags use site name on gallery index
- [ ] Verify no OG tags appear on pages that don't set them
- [ ] Test with a social media link preview tool (e.g. Facebook Sharing Debugger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)