### PR TITLE
Add admin dashboard statistics

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -369,6 +369,54 @@ main {
     border: 1px solid #a9dfbf;
 }
 
+/* Admin Stats Bar */
+.stats-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.stat-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem 1.25rem;
+    min-width: 130px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.stat-card-wide {
+    min-width: 200px;
+    flex: 1;
+}
+
+.stat-value {
+    font-size: 1.8rem;
+    font-weight: bold;
+    color: var(--accent);
+    line-height: 1.2;
+}
+
+.stat-value-sm {
+    font-size: 1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
+}
+
+.stat-label {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    margin-top: 0.25rem;
+}
+
 /* Admin */
 .admin-table {
     width: 100%;
@@ -563,5 +611,18 @@ main {
 
     .admin-table {
         min-width: 700px;
+    }
+
+    .stats-bar {
+        gap: 0.75rem;
+    }
+
+    .stat-card {
+        min-width: calc(50% - 0.75rem);
+        flex: 1 1 calc(50% - 0.75rem);
+    }
+
+    .stat-card-wide {
+        min-width: 100%;
     }
 }

--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -58,6 +58,25 @@ class AdminController
             [':limit' => $perPage, ':offset' => $offset]
         );
 
+        $stats = [
+            'total_paintings' => (int) $this->db->scalar('SELECT COUNT(*) FROM paintings'),
+            'available' => (int) $this->db->scalar('SELECT COUNT(*) FROM paintings WHERE awarded_to IS NULL'),
+            'awarded' => (int) $this->db->scalar('SELECT COUNT(*) FROM paintings WHERE awarded_to IS NOT NULL'),
+            'total_users' => (int) $this->db->scalar('SELECT COUNT(*) FROM users'),
+            'total_interests' => (int) $this->db->scalar('SELECT COUNT(*) FROM interests'),
+        ];
+
+        $mostWanted = $this->db->fetchOne(
+            'SELECT p.title, COUNT(i.id) AS cnt
+             FROM paintings p
+             JOIN interests i ON i.painting_id = p.id
+             WHERE p.awarded_to IS NULL
+             GROUP BY p.id
+             ORDER BY cnt DESC
+             LIMIT 1'
+        );
+        $stats['most_wanted'] = $mostWanted['title'] ?? null;
+
         Template::render('admin/dashboard', [
             'paintings' => $paintings,
             'page' => $page,
@@ -66,6 +85,7 @@ class AdminController
             'filter' => $filter,
             'sort' => $sort,
             'dir' => $dir,
+            'stats' => $stats,
             'auth' => $this->auth,
         ]);
     }

--- a/templates/admin/dashboard.php
+++ b/templates/admin/dashboard.php
@@ -13,6 +13,34 @@ $sortIndicator = function (string $col) use ($sort, $dir): string {
 ?>
 
 <h1>Admin Dashboard</h1>
+
+<div class="stats-bar">
+    <div class="stat-card">
+        <span class="stat-value"><?= $stats['total_paintings'] ?></span>
+        <span class="stat-label">Total Paintings</span>
+    </div>
+    <div class="stat-card">
+        <span class="stat-value"><?= $stats['available'] ?></span>
+        <span class="stat-label">Available</span>
+    </div>
+    <div class="stat-card">
+        <span class="stat-value"><?= $stats['awarded'] ?></span>
+        <span class="stat-label">Awarded</span>
+    </div>
+    <div class="stat-card">
+        <span class="stat-value"><?= $stats['total_users'] ?></span>
+        <span class="stat-label">Users</span>
+    </div>
+    <div class="stat-card">
+        <span class="stat-value"><?= $stats['total_interests'] ?></span>
+        <span class="stat-label">Interests</span>
+    </div>
+    <div class="stat-card stat-card-wide">
+        <span class="stat-value stat-value-sm"><?= $stats['most_wanted'] ? Template::escape($stats['most_wanted']) : '&mdash;' ?></span>
+        <span class="stat-label">Most Wanted</span>
+    </div>
+</div>
+
 <p style="color:var(--text-muted);margin-bottom:1rem;"><?= $total ?> paintings (<?= $filter ?>)</p>
 
 <div class="filter-bar">

--- a/tests/AdminStatsTest.php
+++ b/tests/AdminStatsTest.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Database;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class AdminStatsTest extends TestCase
+{
+    private Database $db;
+
+    protected function setUp(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        $pdo->exec('CREATE TABLE paintings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            description TEXT,
+            filename TEXT,
+            original_filename TEXT,
+            awarded_to INTEGER,
+            awarded_at TEXT,
+            tracking_number TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )');
+
+        $pdo->exec('CREATE TABLE users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            email TEXT,
+            shipping_address TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )');
+
+        $pdo->exec('CREATE TABLE interests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            painting_id INTEGER NOT NULL,
+            user_id INTEGER NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )');
+
+        $this->db = new Database($pdo);
+    }
+
+    public function testTotalPaintingsCount(): void
+    {
+        $this->db->execute("INSERT INTO paintings (title, filename) VALUES ('A', 'a.jpg')");
+        $this->db->execute("INSERT INTO paintings (title, filename) VALUES ('B', 'b.jpg')");
+        $this->db->execute("INSERT INTO paintings (title, filename, awarded_to) VALUES ('C', 'c.jpg', 1)");
+
+        $total = (int) $this->db->scalar('SELECT COUNT(*) FROM paintings');
+        $this->assertSame(3, $total);
+    }
+
+    public function testAvailablePaintingsCount(): void
+    {
+        $this->db->execute("INSERT INTO paintings (title, filename) VALUES ('A', 'a.jpg')");
+        $this->db->execute("INSERT INTO paintings (title, filename) VALUES ('B', 'b.jpg')");
+        $this->db->execute("INSERT INTO paintings (title, filename, awarded_to) VALUES ('C', 'c.jpg', 1)");
+
+        $available = (int) $this->db->scalar('SELECT COUNT(*) FROM paintings WHERE awarded_to IS NULL');
+        $this->assertSame(2, $available);
+    }
+
+    public function testAwardedPaintingsCount(): void
+    {
+        $this->db->execute("INSERT INTO paintings (title, filename) VALUES ('A', 'a.jpg')");
+        $this->db->execute("INSERT INTO paintings (title, filename, awarded_to) VALUES ('B', 'b.jpg', 1)");
+        $this->db->execute("INSERT INTO paintings (title, filename, awarded_to) VALUES ('C', 'c.jpg', 2)");
+
+        $awarded = (int) $this->db->scalar('SELECT COUNT(*) FROM paintings WHERE awarded_to IS NOT NULL');
+        $this->assertSame(2, $awarded);
+    }
+
+    public function testTotalUsersCount(): void
+    {
+        $this->db->execute("INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')");
+        $this->db->execute("INSERT INTO users (name, email) VALUES ('Bob', 'bob@example.com')");
+
+        $totalUsers = (int) $this->db->scalar('SELECT COUNT(*) FROM users');
+        $this->assertSame(2, $totalUsers);
+    }
+
+    public function testTotalInterestsCount(): void
+    {
+        $this->db->execute("INSERT INTO paintings (title, filename) VALUES ('A', 'a.jpg')");
+        $this->db->execute("INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')");
+        $this->db->execute("INSERT INTO interests (painting_id, user_id) VALUES (1, 1)");
+        $this->db->execute("INSERT INTO interests (painting_id, user_id) VALUES (1, 1)");
+        $this->db->execute("INSERT INTO interests (painting_id, user_id) VALUES (1, 1)");
+
+        $totalInterests = (int) $this->db->scalar('SELECT COUNT(*) FROM interests');
+        $this->assertSame(3, $totalInterests);
+    }
+
+    public function testMostWantedPaintingTitle(): void
+    {
+        $this->db->execute("INSERT INTO paintings (title, filename) VALUES ('Sunset', 'sunset.jpg')");
+        $this->db->execute("INSERT INTO paintings (title, filename) VALUES ('Mountains', 'mountains.jpg')");
+        $this->db->execute("INSERT INTO users (name, email) VALUES ('Alice', 'a@example.com')");
+        $this->db->execute("INSERT INTO users (name, email) VALUES ('Bob', 'b@example.com')");
+        $this->db->execute("INSERT INTO users (name, email) VALUES ('Carol', 'c@example.com')");
+
+        // Mountains gets 3 interests, Sunset gets 1
+        $this->db->execute("INSERT INTO interests (painting_id, user_id) VALUES (2, 1)");
+        $this->db->execute("INSERT INTO interests (painting_id, user_id) VALUES (2, 2)");
+        $this->db->execute("INSERT INTO interests (painting_id, user_id) VALUES (2, 3)");
+        $this->db->execute("INSERT INTO interests (painting_id, user_id) VALUES (1, 1)");
+
+        $mostWanted = $this->db->fetchOne(
+            'SELECT p.title, COUNT(i.id) AS cnt
+             FROM paintings p
+             JOIN interests i ON i.painting_id = p.id
+             WHERE p.awarded_to IS NULL
+             GROUP BY p.id
+             ORDER BY cnt DESC
+             LIMIT 1'
+        );
+
+        $this->assertNotNull($mostWanted);
+        $this->assertSame('Mountains', $mostWanted['title']);
+    }
+
+    public function testMostWantedReturnsNullWhenNoInterests(): void
+    {
+        $this->db->execute("INSERT INTO paintings (title, filename) VALUES ('Lonely', 'lonely.jpg')");
+
+        $mostWanted = $this->db->fetchOne(
+            'SELECT p.title, COUNT(i.id) AS cnt
+             FROM paintings p
+             JOIN interests i ON i.painting_id = p.id
+             WHERE p.awarded_to IS NULL
+             GROUP BY p.id
+             ORDER BY cnt DESC
+             LIMIT 1'
+        );
+
+        $this->assertNull($mostWanted);
+    }
+
+    public function testStatsWithEmptyDatabase(): void
+    {
+        $total = (int) $this->db->scalar('SELECT COUNT(*) FROM paintings');
+        $available = (int) $this->db->scalar('SELECT COUNT(*) FROM paintings WHERE awarded_to IS NULL');
+        $awarded = (int) $this->db->scalar('SELECT COUNT(*) FROM paintings WHERE awarded_to IS NOT NULL');
+        $totalUsers = (int) $this->db->scalar('SELECT COUNT(*) FROM users');
+        $totalInterests = (int) $this->db->scalar('SELECT COUNT(*) FROM interests');
+
+        $this->assertSame(0, $total);
+        $this->assertSame(0, $available);
+        $this->assertSame(0, $awarded);
+        $this->assertSame(0, $totalUsers);
+        $this->assertSame(0, $totalInterests);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a statistics summary bar at the top of the admin dashboard showing total paintings, available, awarded, total users, total interests, and the most-wanted painting title
- Styled stat cards with responsive layout that adapts to mobile
- 8 new PHPUnit tests in `AdminStatsTest.php` covering all stat queries including edge cases (empty DB, no interests)

Closes #45

## Test plan
- [ ] Verify `composer check` passes (252 tests + 29 specs all green)
- [ ] Confirm stat cards render correctly on the admin dashboard
- [ ] Check responsive layout on mobile viewport
- [ ] Verify most-wanted shows the painting with the highest interest count among available paintings

Generated with [Claude Code](https://claude.com/claude-code)