### PR TITLE
Add robots.txt and sitemap.xml

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -59,6 +59,7 @@ $authCtrl = new AuthController($db, $auth, $settings);
 $admin = new AdminController($db, $auth, $settings);
 
 // Public routes
+$router->get('/sitemap.xml', [$gallery, 'sitemapXml']);
 $router->get('/', [$gallery, 'index']);
 $router->get('/painting/{id}', [$gallery, 'show']);
 $router->post('/painting/{id}/interest', [$gallery, 'expressInterest']);

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+Allow: /
+Disallow: /admin/
+Disallow: /auth/
+Disallow: /profile
+Disallow: /set-password
+Disallow: /my-paintings
+
+Sitemap: http://localhost:8080/sitemap.xml

--- a/src/Controllers/GalleryController.php
+++ b/src/Controllers/GalleryController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Heirloom\Controllers;
 
 use Heirloom\Auth;
+use Heirloom\Config;
 use Heirloom\Database;
 use Heirloom\SiteSettings;
 use Heirloom\Template;
@@ -147,6 +148,44 @@ class GalleryController
         }
         header('Location: ' . $redirect);
         exit;
+    }
+
+    public function sitemapXml(): void
+    {
+        $appUrl = rtrim(Config::get('APP_URL', 'http://localhost:8080'), '/');
+
+        $paintings = $this->db->fetchAll(
+            'SELECT id, updated_at FROM paintings WHERE awarded_to IS NULL ORDER BY created_at DESC'
+        );
+
+        header('Content-Type: text/xml; charset=UTF-8');
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+        $xml .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+
+        // Gallery home page
+        $xml .= "  <url>\n";
+        $xml .= '    <loc>' . htmlspecialchars($appUrl . '/') . "</loc>\n";
+        $xml .= "    <changefreq>daily</changefreq>\n";
+        $xml .= "    <priority>1.0</priority>\n";
+        $xml .= "  </url>\n";
+
+        // Individual painting pages
+        foreach ($paintings as $painting) {
+            $loc = $appUrl . '/painting/' . $painting['id'];
+            $xml .= "  <url>\n";
+            $xml .= '    <loc>' . htmlspecialchars($loc) . "</loc>\n";
+            if (!empty($painting['updated_at'])) {
+                $xml .= '    <lastmod>' . date('Y-m-d', strtotime($painting['updated_at'])) . "</lastmod>\n";
+            }
+            $xml .= "    <changefreq>weekly</changefreq>\n";
+            $xml .= "    <priority>0.8</priority>\n";
+            $xml .= "  </url>\n";
+        }
+
+        $xml .= "</urlset>\n";
+
+        echo $xml;
     }
 
     public function myPaintings(): void


### PR DESCRIPTION
## Summary
- Add static `public/robots.txt` blocking `/admin/`, `/auth/`, `/profile`, `/set-password`, and `/my-paintings` from crawlers
- Add dynamic `GET /sitemap.xml` route served by `GalleryController::sitemapXml()`, which queries all available paintings and outputs valid sitemap XML including the gallery home page and each painting detail page
- Uses `APP_URL` from environment config for absolute URLs

Closes #46

## Test plan
- [ ] Verify `GET /robots.txt` returns correct directives
- [ ] Verify `GET /sitemap.xml` returns valid XML with `Content-Type: text/xml`
- [ ] Confirm all available (non-awarded) paintings appear in the sitemap
- [ ] Confirm awarded paintings are excluded from the sitemap
- [ ] Run `composer check` -- all 244 tests and 29 specs pass

Generated with [Claude Code](https://claude.com/claude-code)