### PR TITLE
Add data export for admin (paintings CSV, users CSV) — closes #48

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -87,6 +87,8 @@ $router->post('/admin/painting/{id}/edit', [$admin, 'edit']);
 $router->post('/admin/painting/{id}/award', [$admin, 'award']);
 $router->post('/admin/painting/{id}/tracking', [$admin, 'updateTracking']);
 $router->post('/admin/painting/{id}/delete', [$admin, 'delete']);
+$router->get('/admin/export/paintings', [$admin, 'exportPaintings']);
+$router->get('/admin/export/users', [$admin, 'exportUsers']);
 $router->get('/admin/settings', [$admin, 'settingsForm']);
 $router->post('/admin/settings', [$admin, 'updateSettings']);
 

--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -327,6 +327,127 @@ class AdminController
         exit;
     }
 
+    // ---------------------------------------------------------------
+    // CSV exports
+    // ---------------------------------------------------------------
+
+    /** Return the header row for the paintings CSV. */
+    public static function paintingsCsvHeader(): array
+    {
+        return [
+            'ID',
+            'Title',
+            'Description',
+            'Filename',
+            'Interest Count',
+            'Awarded To Name',
+            'Awarded To Email',
+            'Awarded At',
+            'Tracking Number',
+            'Created At',
+        ];
+    }
+
+    /** Query all paintings with interest count and awarded-user info. */
+    public static function paintingsCsvRows(Database $db): array
+    {
+        return $db->fetchAll(
+            "SELECT p.id, p.title, p.description, p.filename,
+                    (SELECT COUNT(*) FROM interests i WHERE i.painting_id = p.id) AS interest_count,
+                    u.name AS awarded_name, u.email AS awarded_email,
+                    p.awarded_at, p.tracking_number, p.created_at
+             FROM paintings p
+             LEFT JOIN users u ON u.id = p.awarded_to
+             ORDER BY p.id"
+        );
+    }
+
+    /** Stream paintings CSV to the browser. */
+    public function exportPaintings(): void
+    {
+        $this->auth->requireAdmin();
+
+        header('Content-Type: text/csv; charset=utf-8');
+        header('Content-Disposition: attachment; filename="paintings_' . date('Y-m-d') . '.csv"');
+
+        $out = fopen('php://output', 'w');
+        fputcsv($out, self::paintingsCsvHeader());
+
+        foreach (self::paintingsCsvRows($this->db) as $row) {
+            fputcsv($out, [
+                $row['id'],
+                $row['title'],
+                $row['description'],
+                $row['filename'],
+                $row['interest_count'],
+                $row['awarded_name'] ?? '',
+                $row['awarded_email'] ?? '',
+                $row['awarded_at'] ?? '',
+                $row['tracking_number'] ?? '',
+                $row['created_at'],
+            ]);
+        }
+
+        fclose($out);
+        exit;
+    }
+
+    /** Return the header row for the users CSV. */
+    public static function usersCsvHeader(): array
+    {
+        return [
+            'ID',
+            'Email',
+            'Name',
+            'Shipping Address',
+            'Interest Count',
+            'Awarded Painting Count',
+            'Is Admin',
+            'Created At',
+        ];
+    }
+
+    /** Query all users with interest count and awarded painting count. */
+    public static function usersCsvRows(Database $db): array
+    {
+        return $db->fetchAll(
+            "SELECT u.id, u.email, u.name, u.shipping_address,
+                    (SELECT COUNT(*) FROM interests i WHERE i.user_id = u.id) AS interest_count,
+                    (SELECT COUNT(*) FROM paintings p WHERE p.awarded_to = u.id) AS awarded_count,
+                    u.is_admin, u.created_at
+             FROM users u
+             ORDER BY u.id"
+        );
+    }
+
+    /** Stream users CSV to the browser. */
+    public function exportUsers(): void
+    {
+        $this->auth->requireAdmin();
+
+        header('Content-Type: text/csv; charset=utf-8');
+        header('Content-Disposition: attachment; filename="users_' . date('Y-m-d') . '.csv"');
+
+        $out = fopen('php://output', 'w');
+        fputcsv($out, self::usersCsvHeader());
+
+        foreach (self::usersCsvRows($this->db) as $row) {
+            fputcsv($out, [
+                $row['id'],
+                $row['email'],
+                $row['name'],
+                $row['shipping_address'] ?? '',
+                $row['interest_count'],
+                $row['awarded_count'],
+                $row['is_admin'] ? 'Yes' : 'No',
+                $row['created_at'],
+            ]);
+        }
+
+        fclose($out);
+        exit;
+    }
+
     public function settingsForm(): void
     {
         $this->auth->requireAdmin();

--- a/templates/admin/dashboard.php
+++ b/templates/admin/dashboard.php
@@ -20,7 +20,9 @@ $sortIndicator = function (string $col) use ($sort, $dir): string {
     <a href="/admin?filter=wanted" class="<?= $filter === 'wanted' ? 'active' : '' ?>">Wanted</a>
     <a href="/admin?filter=awarded" class="<?= $filter === 'awarded' ? 'active' : '' ?>">Awarded</a>
     <a href="/admin?filter=all" class="<?= $filter === 'all' ? 'active' : '' ?>">All</a>
-    <a href="/admin/upload" class="btn btn-primary btn-sm" style="margin-left:auto">Upload Paintings</a>
+    <a href="/admin/export/paintings" class="btn btn-sm" style="margin-left:auto">Export Paintings CSV</a>
+    <a href="/admin/export/users" class="btn btn-sm">Export Users CSV</a>
+    <a href="/admin/upload" class="btn btn-primary btn-sm">Upload Paintings</a>
 </div>
 
 <?php if (empty($paintings)): ?>

--- a/tests/CsvExportTest.php
+++ b/tests/CsvExportTest.php
@@ -1,0 +1,156 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Controllers\AdminController;
+use Heirloom\Database;
+use Heirloom\SiteSettings;
+use Heirloom\Tests\Controllers\ControllerTestSchema;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the CSV export queries and output used by AdminController.
+ *
+ * Validates that paintings and users CSV exports contain the expected
+ * header rows and that data rows match database content.
+ */
+class CsvExportTest extends TestCase
+{
+    use ControllerTestSchema;
+
+    protected function setUp(): void
+    {
+        $this->createDatabase();
+    }
+
+    // ---------------------------------------------------------------
+    // Paintings CSV
+    // ---------------------------------------------------------------
+
+    public function testPaintingsCsvHeaderRow(): void
+    {
+        $header = AdminController::paintingsCsvHeader();
+
+        $this->assertSame([
+            'ID',
+            'Title',
+            'Description',
+            'Filename',
+            'Interest Count',
+            'Awarded To Name',
+            'Awarded To Email',
+            'Awarded At',
+            'Tracking Number',
+            'Created At',
+        ], $header);
+    }
+
+    public function testPaintingsCsvDataMatchesDb(): void
+    {
+        $alice = $this->insertUser('alice@test.com', 'Alice');
+        $bob = $this->insertUser('bob@test.com', 'Bob');
+
+        $p1 = $this->insertPainting('Sunset', $alice, 'A warm sunset');
+        $this->db->execute(
+            'UPDATE paintings SET tracking_number = :tn WHERE id = :id',
+            [':tn' => 'TRACK123', ':id' => $p1]
+        );
+
+        $p2 = $this->insertPainting('Forest', null, 'Deep woods');
+
+        $this->insertInterest($p1, $bob);
+        $this->insertInterest($p2, $alice);
+        $this->insertInterest($p2, $bob);
+
+        $rows = AdminController::paintingsCsvRows($this->db);
+
+        $this->assertCount(2, $rows);
+
+        // Find the Sunset row
+        $sunset = null;
+        $forest = null;
+        foreach ($rows as $row) {
+            if ($row['title'] === 'Sunset') {
+                $sunset = $row;
+            }
+            if ($row['title'] === 'Forest') {
+                $forest = $row;
+            }
+        }
+
+        $this->assertNotNull($sunset);
+        $this->assertSame(1, (int) $sunset['interest_count']);
+        $this->assertSame('Alice', $sunset['awarded_name']);
+        $this->assertSame('alice@test.com', $sunset['awarded_email']);
+        $this->assertSame('TRACK123', $sunset['tracking_number']);
+
+        $this->assertNotNull($forest);
+        $this->assertSame(2, (int) $forest['interest_count']);
+        $this->assertNull($forest['awarded_name']);
+        $this->assertNull($forest['awarded_email']);
+    }
+
+    // ---------------------------------------------------------------
+    // Users CSV
+    // ---------------------------------------------------------------
+
+    public function testUsersCsvHeaderRow(): void
+    {
+        $header = AdminController::usersCsvHeader();
+
+        $this->assertSame([
+            'ID',
+            'Email',
+            'Name',
+            'Shipping Address',
+            'Interest Count',
+            'Awarded Painting Count',
+            'Is Admin',
+            'Created At',
+        ], $header);
+    }
+
+    public function testUsersCsvDataMatchesDb(): void
+    {
+        $alice = $this->insertUser('alice@test.com', 'Alice');
+        $bob = $this->insertUser('bob@test.com', 'Bob');
+        $this->db->execute(
+            'UPDATE users SET shipping_address = :addr WHERE id = :id',
+            [':addr' => '123 Main St', ':id' => $alice]
+        );
+
+        $p1 = $this->insertPainting('Sunset', $alice);
+        $p2 = $this->insertPainting('Dawn', $alice);
+        $p3 = $this->insertPainting('Forest');
+
+        $this->insertInterest($p1, $bob);
+        $this->insertInterest($p3, $bob);
+        $this->insertInterest($p3, $alice);
+
+        $rows = AdminController::usersCsvRows($this->db);
+
+        $this->assertCount(2, $rows);
+
+        $aliceRow = null;
+        $bobRow = null;
+        foreach ($rows as $row) {
+            if ($row['email'] === 'alice@test.com') {
+                $aliceRow = $row;
+            }
+            if ($row['email'] === 'bob@test.com') {
+                $bobRow = $row;
+            }
+        }
+
+        $this->assertNotNull($aliceRow);
+        $this->assertSame('Alice', $aliceRow['name']);
+        $this->assertSame('123 Main St', $aliceRow['shipping_address']);
+        $this->assertSame(1, (int) $aliceRow['interest_count']);
+        $this->assertSame(2, (int) $aliceRow['awarded_count']);
+
+        $this->assertNotNull($bobRow);
+        $this->assertSame(2, (int) $bobRow['interest_count']);
+        $this->assertSame(0, (int) $bobRow['awarded_count']);
+    }
+}


### PR DESCRIPTION
## Summary
- exportPaintings() and exportUsers() on AdminController with CSV streaming
- Routes: GET /admin/export/paintings and GET /admin/export/users
- Export buttons on dashboard filter bar
- 4 new tests

Closes #48