### PR TITLE
Fix broken gallery images for pre-thumbnail paintings

### DIFF
--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -71,4 +71,19 @@ class Thumbnail
         $base = pathinfo($filename, PATHINFO_FILENAME);
         return $base . '_thumb.' . $ext;
     }
+
+    /**
+     * Return the thumbnail filename if the file exists on disk, otherwise the original.
+     */
+    public static function thumbOrOriginal(string $filename, string $uploadDir = ''): string
+    {
+        if ($uploadDir === '') {
+            $uploadDir = dirname(__DIR__) . '/public/uploads/';
+        }
+        $thumb = self::thumbFilename($filename);
+        if (file_exists($uploadDir . $thumb)) {
+            return $thumb;
+        }
+        return $filename;
+    }
 }

--- a/templates/gallery.php
+++ b/templates/gallery.php
@@ -37,7 +37,7 @@ if ($sort !== 'newest') {
             <div class="painting-card">
                 <a href="/painting/<?= $p['id'] ?>">
                     <img class="painting-card-image"
-                         src="/uploads/<?= Template::escape(Thumbnail::thumbFilename($p['filename'])) ?>"
+                         src="/uploads/<?= Template::escape(Thumbnail::thumbOrOriginal($p['filename'])) ?>"
                          alt="<?= Template::escape($p['title']) ?>"
                          loading="lazy">
                     <div class="painting-card-body">

--- a/tests/ThumbnailTest.php
+++ b/tests/ThumbnailTest.php
@@ -123,4 +123,24 @@ class ThumbnailTest extends TestCase
         $this->assertSame(200, $info[0]);
         $this->assertSame(150, $info[1]);
     }
+
+    public function testThumbOrOriginalReturnsThumbWhenExists(): void
+    {
+        $original = $this->tmpDir . '/abc123.jpg';
+        $thumb = $this->tmpDir . '/abc123_thumb.jpg';
+        file_put_contents($original, 'original');
+        file_put_contents($thumb, 'thumb');
+
+        $result = Thumbnail::thumbOrOriginal('abc123.jpg', $this->tmpDir . '/');
+        $this->assertSame('abc123_thumb.jpg', $result);
+    }
+
+    public function testThumbOrOriginalFallsBackToOriginal(): void
+    {
+        $original = $this->tmpDir . '/noThumb.png';
+        file_put_contents($original, 'original');
+
+        $result = Thumbnail::thumbOrOriginal('noThumb.png', $this->tmpDir . '/');
+        $this->assertSame('noThumb.png', $result);
+    }
 }


### PR DESCRIPTION
## Summary
- Gallery was referencing `_thumb` filenames that don't exist for paintings uploaded before the thumbnail feature
- New `Thumbnail::thumbOrOriginal()` checks if thumb exists on disk, falls back to original
- 2 new tests

## Test plan
- [ ] Gallery shows images for old paintings (no thumbnails)
- [ ] New uploads still use thumbnails