### PR TITLE
Add HTTP security headers

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -30,6 +30,14 @@ set_exception_handler(function (\Throwable $e): void {
 
 session_start();
 
+header('X-Frame-Options: DENY');
+header('X-Content-Type-Options: nosniff');
+header('X-XSS-Protection: 1; mode=block');
+header('Referrer-Policy: strict-origin-when-cross-origin');
+if (!empty($_SERVER['HTTPS'])) {
+    header('Strict-Transport-Security: max-age=31536000; includeSubDomains');
+}
+
 $db = Database::getInstance();
 $settings = new SiteSettings($db);
 Template::setGlobal('siteName', $settings->get('site_name', SiteSettings::DEFAULT_SITE_NAME));


### PR DESCRIPTION
## Summary
- Adds HTTP security headers (`X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, `Referrer-Policy`) after `session_start()` in `public/index.php`
- Adds `Strict-Transport-Security` header when HTTPS is active
- Closes #65

## Test plan
- [ ] Verify headers are present in HTTP responses (e.g., via browser dev tools or `curl -I`)
- [ ] Confirm HSTS header only appears over HTTPS connections
- [ ] Confirm `composer check` passes (tests + specs all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)