### PR TITLE
Harden session configuration

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -28,6 +28,12 @@ set_exception_handler(function (\Throwable $e): void {
     ]);
 });
 
+ini_set('session.use_strict_mode', '1');
+ini_set('session.use_only_cookies', '1');
+ini_set('session.cookie_httponly', '1');
+if (!empty($_SERVER['HTTPS'])) {
+    ini_set('session.cookie_secure', '1');
+}
 session_start();
 
 $db = Database::getInstance();


### PR DESCRIPTION
## Summary
- Adds `session.use_strict_mode`, `session.use_only_cookies`, and `session.cookie_httponly` ini directives before `session_start()` to prevent session fixation and cookie hijacking
- Conditionally sets `session.cookie_secure` when HTTPS is active

Closes #68

## Test plan
- [x] `composer check` passes (277 tests, 29 specs)
- [ ] Verify session cookies include `HttpOnly` flag in browser dev tools
- [ ] Verify `Secure` flag is set when served over HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)