### PR TITLE
Add server-side validation for admin site settings (closes #66)

### DIFF
--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -509,10 +509,67 @@ class AdminController
             }
         }
 
-        $this->settings->setBulk($updates);
-        $_SESSION['admin_success'] = 'Settings saved.';
+        $errors = self::validateSettings($updates);
+
+        if ($errors) {
+            // Only save settings that passed validation
+            $valid = array_diff_key($updates, $errors);
+            if ($valid) {
+                $this->settings->setBulk($valid);
+            }
+            $_SESSION['admin_error'] = implode(' ', array_values($errors));
+        } else {
+            $this->settings->setBulk($updates);
+            $_SESSION['admin_success'] = 'Settings saved.';
+        }
+
         header('Location: /admin/settings');
         exit;
+    }
+
+    /**
+     * Validate setting values. Returns an associative array of setting_key => error message
+     * for any settings that fail validation. An empty array means all valid.
+     *
+     * @param array<string, string> $settings Map of setting_key => value to validate
+     * @return array<string, string> Map of setting_key => error message for invalid settings
+     */
+    public static function validateSettings(array $settings): array
+    {
+        $errors = [];
+
+        $numericKeys = [
+            'magic_link_expiry_minutes',
+            'session_timeout_minutes',
+            'gallery_per_page',
+            'admin_per_page',
+        ];
+
+        $booleanKeys = [
+            'registration_open',
+        ];
+
+        foreach ($settings as $key => $value) {
+            if (in_array($key, $numericKeys, true)) {
+                if (!ctype_digit($value) || (int) $value < 1) {
+                    $errors[$key] = "$key must be a positive integer.";
+                }
+            } elseif (in_array($key, $booleanKeys, true)) {
+                if ($value !== '0' && $value !== '1') {
+                    $errors[$key] = "$key must be '0' or '1'.";
+                }
+            } elseif ($key === 'contact_email') {
+                if ($value !== '' && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                    $errors[$key] = 'contact_email must be a valid email or empty.';
+                }
+            } elseif ($key === 'site_name') {
+                if (mb_strlen($value) > 100) {
+                    $errors[$key] = 'site_name must not exceed 100 characters.';
+                }
+            }
+        }
+
+        return $errors;
     }
 
     public function inviteForm(): void

--- a/tests/SettingsValidationTest.php
+++ b/tests/SettingsValidationTest.php
@@ -1,0 +1,182 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Controllers\AdminController;
+use PHPUnit\Framework\TestCase;
+
+class SettingsValidationTest extends TestCase
+{
+    // ── Numeric settings: must be integers >= 1 ──
+
+    /**
+     * @dataProvider numericSettingKeysProvider
+     */
+    public function testNumericSettingRejectsZero(string $key): void
+    {
+        $errors = AdminController::validateSettings([$key => '0']);
+        $this->assertArrayHasKey($key, $errors);
+    }
+
+    /**
+     * @dataProvider numericSettingKeysProvider
+     */
+    public function testNumericSettingRejectsNegative(string $key): void
+    {
+        $errors = AdminController::validateSettings([$key => '-5']);
+        $this->assertArrayHasKey($key, $errors);
+    }
+
+    /**
+     * @dataProvider numericSettingKeysProvider
+     */
+    public function testNumericSettingRejectsNonInteger(string $key): void
+    {
+        $errors = AdminController::validateSettings([$key => 'abc']);
+        $this->assertArrayHasKey($key, $errors);
+    }
+
+    /**
+     * @dataProvider numericSettingKeysProvider
+     */
+    public function testNumericSettingRejectsFloat(string $key): void
+    {
+        $errors = AdminController::validateSettings([$key => '3.5']);
+        $this->assertArrayHasKey($key, $errors);
+    }
+
+    /**
+     * @dataProvider numericSettingKeysProvider
+     */
+    public function testNumericSettingAcceptsPositiveInteger(string $key): void
+    {
+        $errors = AdminController::validateSettings([$key => '10']);
+        $this->assertArrayNotHasKey($key, $errors);
+    }
+
+    /**
+     * @dataProvider numericSettingKeysProvider
+     */
+    public function testNumericSettingAcceptsOne(string $key): void
+    {
+        $errors = AdminController::validateSettings([$key => '1']);
+        $this->assertArrayNotHasKey($key, $errors);
+    }
+
+    public static function numericSettingKeysProvider(): array
+    {
+        return [
+            'magic_link_expiry_minutes' => ['magic_link_expiry_minutes'],
+            'session_timeout_minutes' => ['session_timeout_minutes'],
+            'gallery_per_page' => ['gallery_per_page'],
+            'admin_per_page' => ['admin_per_page'],
+        ];
+    }
+
+    // ── Boolean setting: registration_open ──
+
+    public function testBooleanSettingAcceptsOne(): void
+    {
+        $errors = AdminController::validateSettings(['registration_open' => '1']);
+        $this->assertArrayNotHasKey('registration_open', $errors);
+    }
+
+    public function testBooleanSettingAcceptsZero(): void
+    {
+        $errors = AdminController::validateSettings(['registration_open' => '0']);
+        $this->assertArrayNotHasKey('registration_open', $errors);
+    }
+
+    public function testBooleanSettingRejectsArbitraryString(): void
+    {
+        $errors = AdminController::validateSettings(['registration_open' => 'yes']);
+        $this->assertArrayHasKey('registration_open', $errors);
+    }
+
+    public function testBooleanSettingRejectsNumericOtherThanZeroOrOne(): void
+    {
+        $errors = AdminController::validateSettings(['registration_open' => '2']);
+        $this->assertArrayHasKey('registration_open', $errors);
+    }
+
+    // ── Email: contact_email ──
+
+    public function testContactEmailAcceptsValidEmail(): void
+    {
+        $errors = AdminController::validateSettings(['contact_email' => 'admin@example.com']);
+        $this->assertArrayNotHasKey('contact_email', $errors);
+    }
+
+    public function testContactEmailAcceptsEmptyString(): void
+    {
+        $errors = AdminController::validateSettings(['contact_email' => '']);
+        $this->assertArrayNotHasKey('contact_email', $errors);
+    }
+
+    public function testContactEmailRejectsInvalidEmail(): void
+    {
+        $errors = AdminController::validateSettings(['contact_email' => 'not-an-email']);
+        $this->assertArrayHasKey('contact_email', $errors);
+    }
+
+    public function testContactEmailRejectsEmailWithoutDomain(): void
+    {
+        $errors = AdminController::validateSettings(['contact_email' => 'user@']);
+        $this->assertArrayHasKey('contact_email', $errors);
+    }
+
+    // ── site_name ──
+
+    public function testSiteNameAcceptsNormalLength(): void
+    {
+        $errors = AdminController::validateSettings(['site_name' => 'My Gallery']);
+        $this->assertArrayNotHasKey('site_name', $errors);
+    }
+
+    public function testSiteNameRejectsOver100Characters(): void
+    {
+        $longName = str_repeat('A', 101);
+        $errors = AdminController::validateSettings(['site_name' => $longName]);
+        $this->assertArrayHasKey('site_name', $errors);
+    }
+
+    public function testSiteNameAcceptsExactly100Characters(): void
+    {
+        $name = str_repeat('A', 100);
+        $errors = AdminController::validateSettings(['site_name' => $name]);
+        $this->assertArrayNotHasKey('site_name', $errors);
+    }
+
+    // ── Mixed inputs ──
+
+    public function testMultipleInvalidSettingsReturnMultipleErrors(): void
+    {
+        $errors = AdminController::validateSettings([
+            'magic_link_expiry_minutes' => '0',
+            'contact_email' => 'bad',
+            'site_name' => str_repeat('X', 200),
+        ]);
+        $this->assertCount(3, $errors);
+    }
+
+    public function testUnknownSettingsPassThroughWithoutError(): void
+    {
+        $errors = AdminController::validateSettings(['unknown_key' => 'whatever']);
+        $this->assertEmpty($errors);
+    }
+
+    public function testValidSettingsReturnNoErrors(): void
+    {
+        $errors = AdminController::validateSettings([
+            'magic_link_expiry_minutes' => '60',
+            'session_timeout_minutes' => '120',
+            'gallery_per_page' => '12',
+            'admin_per_page' => '20',
+            'registration_open' => '1',
+            'contact_email' => 'hello@example.com',
+            'site_name' => 'Heirloom Gallery',
+        ]);
+        $this->assertEmpty($errors);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `AdminController::validateSettings()` static method with validation rules for all setting types
- Numeric settings (magic_link_expiry_minutes, session_timeout_minutes, gallery_per_page, admin_per_page) must be positive integers >= 1
- Boolean settings (registration_open) forced to '0' or '1'
- contact_email validated with filter_var or allowed empty
- site_name capped at 100 characters
- Invalid settings are rejected with error messages; valid settings still save

## Test plan
- [x] 38 new unit tests in `SettingsValidationTest.php` all pass
- [x] Full test suite passes with no regressions
- [ ] Manual: try setting magic_link_expiry_minutes to 0 or -1 — should be rejected
- [ ] Manual: try setting contact_email to invalid value — should be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)