### PR TITLE
Remove hardcoded passwords and reduce error log verbosity (closes #72, closes #73)

### DIFF
--- a/migrate.php
+++ b/migrate.php
@@ -155,9 +155,8 @@ $stmt->execute([':email' => $adminEmail]);
 $existing = $stmt->fetch();
 
 if (!$existing) {
-    $hash = password_hash('foo', PASSWORD_DEFAULT);
-    $stmt = $pdo->prepare('INSERT INTO users (email, name, password_hash, is_admin) VALUES (:email, :name, :hash, 1)');
-    $stmt->execute([':email' => $adminEmail, ':name' => 'Rob Sartin', ':hash' => $hash]);
+    $stmt = $pdo->prepare('INSERT INTO users (email, name, password_hash, is_admin) VALUES (:email, :name, NULL, 1)');
+    $stmt->execute([':email' => $adminEmail, ':name' => 'Rob Sartin']);
     echo "Admin user created: $adminEmail\n";
 } else {
     echo "Admin user already exists.\n";
@@ -168,10 +167,9 @@ $testEmail = 'f@f.com';
 $stmt = $pdo->prepare('SELECT id FROM users WHERE email = :email');
 $stmt->execute([':email' => $testEmail]);
 if (!$stmt->fetch()) {
-    $hash = password_hash('f', PASSWORD_DEFAULT);
-    $stmt = $pdo->prepare('INSERT INTO users (email, name, password_hash) VALUES (:email, :name, :hash)');
-    $stmt->execute([':email' => $testEmail, ':name' => 'Test User', ':hash' => $hash]);
-    echo "Test user created: $testEmail (password: f)\n";
+    $stmt = $pdo->prepare('INSERT INTO users (email, name, password_hash) VALUES (:email, :name, NULL)');
+    $stmt->execute([':email' => $testEmail, ':name' => 'Test User']);
+    echo "Test user created: $testEmail\n";
 } else {
     echo "Test user already exists.\n";
 }

--- a/public/index.php
+++ b/public/index.php
@@ -15,11 +15,12 @@ use Heirloom\Template;
 use Heirloom\Controllers\GalleryController;
 use Heirloom\Controllers\AuthController;
 use Heirloom\Controllers\AdminController;
+use Heirloom\ErrorHandler;
 
 Config::load(__DIR__ . '/../.env');
 
 set_exception_handler(function (\Throwable $e): void {
-    error_log($e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
+    error_log(ErrorHandler::formatError($e));
     http_response_code(500);
     Template::render('error', [
         'code' => 500,

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom;
+
+class ErrorHandler
+{
+    public static function formatError(\Throwable $e): string
+    {
+        $errorId = bin2hex(random_bytes(4));
+        return "[Error $errorId] " . $e->getMessage();
+    }
+}

--- a/tests/ErrorLoggingTest.php
+++ b/tests/ErrorLoggingTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+require_once __DIR__ . '/../src/ErrorHandler.php';
+
+use Heirloom\ErrorHandler;
+use PHPUnit\Framework\TestCase;
+
+class ErrorLoggingTest extends TestCase
+{
+    public function testFormatErrorReturnsEightCharHexId(): void
+    {
+        $exception = new \RuntimeException('Something went wrong');
+        $result = ErrorHandler::formatError($exception);
+
+        // Extract the error ID from the formatted string: "[Error abcd1234] ..."
+        $this->assertMatchesRegularExpression('/^\[Error [0-9a-f]{8}\] /', $result);
+    }
+
+    public function testFormatErrorIncludesMessage(): void
+    {
+        $exception = new \RuntimeException('Database connection failed');
+        $result = ErrorHandler::formatError($exception);
+
+        $this->assertStringContainsString('Database connection failed', $result);
+    }
+
+    public function testFormatErrorDoesNotIncludeFilePath(): void
+    {
+        $exception = new \RuntimeException('Some error');
+        $result = ErrorHandler::formatError($exception);
+
+        // Should NOT contain the file path or line number
+        $this->assertStringNotContainsString($exception->getFile(), $result);
+        $this->assertStringNotContainsString(':' . $exception->getLine(), $result);
+    }
+}


### PR DESCRIPTION
Fixes #72: Seed users with NULL password_hash instead of hardcoded weak passwords. Fixes #73: Extract error formatting to ErrorHandler::formatError() with 8-char hex error ID, excluding file paths from logs. Adds ErrorLoggingTest with 3 passing tests. Full suite (287 tests) passes.