### PR TITLE
Strengthen password requirements and add rate limiting (closes #69, closes #70)

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -191,14 +191,46 @@ class AuthController
         unset($_SESSION['auth_error'], $_SESSION['auth_success']);
     }
 
+    /**
+     * Validate a password against complexity requirements.
+     *
+     * @return string|null Error message, or null if the password is acceptable.
+     */
+    public static function validatePassword(string $password): ?string
+    {
+        if (strlen($password) < 12) {
+            return 'Password must be at least 12 characters.';
+        }
+        if (!preg_match('/[A-Z]/', $password)) {
+            return 'Password must contain at least one uppercase letter.';
+        }
+        if (!preg_match('/[a-z]/', $password)) {
+            return 'Password must contain at least one lowercase letter.';
+        }
+        if (!preg_match('/[0-9]/', $password)) {
+            return 'Password must contain at least one number.';
+        }
+        return null;
+    }
+
     public function setPassword(): void
     {
         $this->auth->requireLogin();
+
+        $identifier = 'password_change_' . $this->auth->userId();
+        if (!$this->rateLimiter->isAllowed($identifier)) {
+            $_SESSION['auth_error'] = 'Too many attempts. Please try again in 15 minutes.';
+            header('Location: /set-password');
+            exit;
+        }
+        $this->rateLimiter->record($identifier);
+
         $password = $_POST['password'] ?? '';
         $confirm = $_POST['password_confirm'] ?? '';
 
-        if (strlen($password) < 8) {
-            $_SESSION['auth_error'] = 'Password must be at least 8 characters.';
+        $validationError = self::validatePassword($password);
+        if ($validationError !== null) {
+            $_SESSION['auth_error'] = $validationError;
             header('Location: /set-password');
             exit;
         }

--- a/templates/set-password.php
+++ b/templates/set-password.php
@@ -8,8 +8,8 @@
         <form method="POST" action="/set-password">
             <?= \Heirloom\Csrf::hiddenField() ?>
             <div class="form-group">
-                <label for="password">New Password (min 8 characters)</label>
-                <input type="password" name="password" id="password" required minlength="8">
+                <label for="password">New Password (min 12 characters, must include uppercase, lowercase, and a number)</label>
+                <input type="password" name="password" id="password" required minlength="12">
             </div>
             <div class="form-group">
                 <label for="password_confirm">Confirm Password</label>

--- a/tests/PasswordSecurityTest.php
+++ b/tests/PasswordSecurityTest.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Controllers\AuthController;
+use Heirloom\Database;
+use Heirloom\RateLimiter;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class PasswordSecurityTest extends TestCase
+{
+    // -------------------------------------------------------
+    // Password validation tests (via AuthController::validatePassword)
+    // -------------------------------------------------------
+
+    public function testPasswordShorterThan12CharsIsRejected(): void
+    {
+        $this->assertNotNull(
+            AuthController::validatePassword('Short1Aa'),
+            'An 8-character password should be rejected'
+        );
+    }
+
+    public function testPasswordExactly12CharsWithComplexityIsAccepted(): void
+    {
+        $this->assertNull(
+            AuthController::validatePassword('Abcdefghij1a'),
+            'A 12-character password meeting all rules should pass'
+        );
+    }
+
+    public function testPasswordWithoutUppercaseIsRejected(): void
+    {
+        $error = AuthController::validatePassword('abcdefghij1a');
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('uppercase', $error);
+    }
+
+    public function testPasswordWithoutLowercaseIsRejected(): void
+    {
+        $error = AuthController::validatePassword('ABCDEFGHIJ1A');
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('lowercase', $error);
+    }
+
+    public function testPasswordWithoutNumberIsRejected(): void
+    {
+        $error = AuthController::validatePassword('Abcdefghijkl');
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('number', $error);
+    }
+
+    public function testPasswordMeetingAllRequirementsIsAccepted(): void
+    {
+        $this->assertNull(AuthController::validatePassword('StrongPass123'));
+    }
+
+    public function testPasswordTooShortReturnsLengthError(): void
+    {
+        $error = AuthController::validatePassword('Ab1');
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('12 characters', $error);
+    }
+
+    // -------------------------------------------------------
+    // Rate limiting tests for password_change_ identifier
+    // -------------------------------------------------------
+
+    private function makeRateLimiter(): RateLimiter
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+        $pdo->exec("CREATE TABLE login_attempts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            identifier TEXT NOT NULL,
+            attempted_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )");
+        $db = new Database($pdo);
+        return new RateLimiter($db, maxAttempts: 5, windowMinutes: 15);
+    }
+
+    public function testRateLimiterAllowsFirstPasswordChangeAttempt(): void
+    {
+        $limiter = $this->makeRateLimiter();
+        $this->assertTrue($limiter->isAllowed('password_change_42'));
+    }
+
+    public function testRateLimiterBlocksAfter5PasswordChangeAttempts(): void
+    {
+        $limiter = $this->makeRateLimiter();
+        for ($i = 0; $i < 5; $i++) {
+            $limiter->record('password_change_42');
+        }
+        $this->assertFalse($limiter->isAllowed('password_change_42'));
+    }
+
+    public function testRateLimiterPasswordChangeIdentifierFormat(): void
+    {
+        $userId = 99;
+        $identifier = 'password_change_' . $userId;
+        $this->assertSame('password_change_99', $identifier);
+    }
+}


### PR DESCRIPTION
## Summary
- Increases minimum password length from 8 to 12 characters
- Adds complexity requirements: uppercase, lowercase, and number
- Adds rate limiting (5 attempts per 15-minute window) to /set-password using `password_change_{userId}` identifier
- Extracts `AuthController::validatePassword()` as testable static method
- Updates set-password template to show new requirements

## Test plan
- [x] 10 new tests in `PasswordSecurityTest.php` pass
- [x] Full test suite passes with no regressions
- [ ] Manual: try short password — rejected
- [ ] Manual: try password without uppercase/lowercase/number — rejected
- [ ] Manual: submit 5+ times rapidly — rate limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)