### PR TITLE
Add input length limits on user-submitted text fields (closes #71)

### DIFF
--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -5,6 +5,7 @@ namespace Heirloom\Controllers;
 
 use Heirloom\Auth;
 use Heirloom\Database;
+use Heirloom\InputValidator;
 use Heirloom\SiteSettings;
 use Heirloom\Template;
 use Heirloom\Thumbnail;
@@ -119,6 +120,14 @@ class AdminController
 
         $title = trim($_POST['title'] ?? '');
         $description = trim($_POST['description'] ?? '');
+
+        $titleError = InputValidator::validateLength($title, 255, 'Title');
+        $descError = InputValidator::validateLength($description, 5000, 'Description');
+        if ($titleError || $descError) {
+            $_SESSION['upload_error'] = $titleError ?? $descError;
+            header('Location: /admin/upload');
+            exit;
+        }
 
         if (empty($_FILES['paintings']) || !is_array($_FILES['paintings']['name'])) {
             $_SESSION['upload_error'] = 'Please select at least one image.';
@@ -252,6 +261,14 @@ class AdminController
 
         if ($title === '') {
             $_SESSION['admin_error'] = 'Title cannot be empty.';
+            header('Location: /admin/painting/' . $id);
+            exit;
+        }
+
+        $titleError = InputValidator::validateLength($title, 255, 'Title');
+        $descError = InputValidator::validateLength($description, 5000, 'Description');
+        if ($titleError || $descError) {
+            $_SESSION['admin_error'] = $titleError ?? $descError;
             header('Location: /admin/painting/' . $id);
             exit;
         }

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -6,6 +6,7 @@ namespace Heirloom\Controllers;
 use Heirloom\Auth;
 use Heirloom\Config;
 use Heirloom\Database;
+use Heirloom\InputValidator;
 use Heirloom\RateLimiter;
 use Heirloom\SiteSettings;
 use Heirloom\Template;
@@ -241,6 +242,13 @@ class AuthController
     {
         $this->auth->requireLogin();
         $address = trim($_POST['shipping_address'] ?? '');
+
+        $lengthError = InputValidator::validateLength($address, 500, 'Shipping address');
+        if ($lengthError) {
+            $_SESSION['auth_error'] = $lengthError;
+            header('Location: /profile');
+            exit;
+        }
 
         $this->db->execute(
             'UPDATE users SET shipping_address = :addr WHERE id = :id',

--- a/src/Controllers/GalleryController.php
+++ b/src/Controllers/GalleryController.php
@@ -6,6 +6,7 @@ namespace Heirloom\Controllers;
 use Heirloom\Auth;
 use Heirloom\Config;
 use Heirloom\Database;
+use Heirloom\InputValidator;
 use Heirloom\SiteSettings;
 use Heirloom\Template;
 
@@ -145,6 +146,13 @@ class GalleryController
         );
 
         $message = trim($_POST['message'] ?? '');
+
+        $lengthError = InputValidator::validateLength($message, 1000, 'Interest message');
+        if ($lengthError) {
+            $_SESSION['gallery_error'] = $lengthError;
+            header('Location: /painting/' . $id);
+            exit;
+        }
 
         if ($existing) {
             // Toggle off - remove interest

--- a/src/InputValidator.php
+++ b/src/InputValidator.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom;
+
+final class InputValidator
+{
+    /**
+     * @return string|null Error message if too long, null if valid.
+     */
+    public static function validateLength(string $value, int $max, string $fieldName): ?string
+    {
+        if (mb_strlen($value) > $max) {
+            return "{$fieldName} must be {$max} characters or fewer.";
+        }
+
+        return null;
+    }
+}

--- a/tests/InputLengthLimitTest.php
+++ b/tests/InputLengthLimitTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+use Heirloom\InputValidator;
+use PHPUnit\Framework\TestCase;
+
+final class InputLengthLimitTest extends TestCase
+{
+    public function testShippingAddressOver500CharsIsRejected(): void
+    {
+        $value = str_repeat('a', 501);
+        $error = InputValidator::validateLength($value, 500, 'Shipping address');
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('500', $error);
+        $this->assertStringContainsString('Shipping address', $error);
+    }
+
+    public function testShippingAddressAtExactly500CharsIsAccepted(): void
+    {
+        $value = str_repeat('a', 500);
+        $error = InputValidator::validateLength($value, 500, 'Shipping address');
+        $this->assertNull($error);
+    }
+
+    public function testInterestMessageOver1000CharsIsRejected(): void
+    {
+        $value = str_repeat('b', 1001);
+        $error = InputValidator::validateLength($value, 1000, 'Interest message');
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('1000', $error);
+    }
+
+    public function testPaintingTitleOver255CharsIsRejected(): void
+    {
+        $value = str_repeat('c', 256);
+        $error = InputValidator::validateLength($value, 255, 'Title');
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('255', $error);
+    }
+
+    public function testPaintingDescriptionOver5000CharsIsRejected(): void
+    {
+        $value = str_repeat('d', 5001);
+        $error = InputValidator::validateLength($value, 5000, 'Description');
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('5000', $error);
+    }
+
+    public function testEmptyStringIsAccepted(): void
+    {
+        $error = InputValidator::validateLength('', 500, 'Shipping address');
+        $this->assertNull($error);
+    }
+
+    public function testStringUnderLimitIsAccepted(): void
+    {
+        $error = InputValidator::validateLength('hello', 500, 'Shipping address');
+        $this->assertNull($error);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `InputValidator::validateLength()` reusable utility for server-side length checks
- Shipping address: max 500 chars (AuthController::updateProfile)
- Interest message: max 1000 chars (GalleryController::expressInterest)
- Painting title: max 255 chars (AdminController::upload and edit)
- Painting description: max 5000 chars (AdminController::upload and edit)
- Rejects with user-friendly error message if exceeded

## Test plan
- [x] 7 new tests in `InputLengthLimitTest.php` pass
- [x] Full test suite (284 tests) passes with no regressions
- [ ] Manual: submit shipping address >500 chars — rejected
- [ ] Manual: submit interest message >1000 chars — rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)