### PR TITLE
Extract InputValidator length constants (closes #82)

### DIFF
--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -121,8 +121,8 @@ class AdminController
         $title = trim($_POST['title'] ?? '');
         $description = trim($_POST['description'] ?? '');
 
-        $titleError = InputValidator::validateLength($title, 255, 'Title');
-        $descError = InputValidator::validateLength($description, 5000, 'Description');
+        $titleError = InputValidator::validateLength($title, InputValidator::MAX_PAINTING_TITLE, 'Title');
+        $descError = InputValidator::validateLength($description, InputValidator::MAX_PAINTING_DESCRIPTION, 'Description');
         if ($titleError || $descError) {
             $_SESSION['upload_error'] = $titleError ?? $descError;
             header('Location: /admin/upload');
@@ -270,8 +270,8 @@ class AdminController
             exit;
         }
 
-        $titleError = InputValidator::validateLength($title, 255, 'Title');
-        $descError = InputValidator::validateLength($description, 5000, 'Description');
+        $titleError = InputValidator::validateLength($title, InputValidator::MAX_PAINTING_TITLE, 'Title');
+        $descError = InputValidator::validateLength($description, InputValidator::MAX_PAINTING_DESCRIPTION, 'Description');
         if ($titleError || $descError) {
             $_SESSION['admin_error'] = $titleError ?? $descError;
             header('Location: /admin/painting/' . $id);

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -275,7 +275,7 @@ class AuthController
         $this->auth->requireLogin();
         $address = trim($_POST['shipping_address'] ?? '');
 
-        $lengthError = InputValidator::validateLength($address, 500, 'Shipping address');
+        $lengthError = InputValidator::validateLength($address, InputValidator::MAX_SHIPPING_ADDRESS, 'Shipping address');
         if ($lengthError) {
             $_SESSION['auth_error'] = $lengthError;
             header('Location: /profile');

--- a/src/Controllers/GalleryController.php
+++ b/src/Controllers/GalleryController.php
@@ -147,7 +147,7 @@ class GalleryController
 
         $message = trim($_POST['message'] ?? '');
 
-        $lengthError = InputValidator::validateLength($message, 1000, 'Interest message');
+        $lengthError = InputValidator::validateLength($message, InputValidator::MAX_INTEREST_MESSAGE, 'Interest message');
         if ($lengthError) {
             $_SESSION['gallery_error'] = $lengthError;
             header('Location: /painting/' . $id);

--- a/src/InputValidator.php
+++ b/src/InputValidator.php
@@ -5,6 +5,11 @@ namespace Heirloom;
 
 final class InputValidator
 {
+    public const MAX_SHIPPING_ADDRESS = 500;
+    public const MAX_INTEREST_MESSAGE = 1000;
+    public const MAX_PAINTING_TITLE = 255;
+    public const MAX_PAINTING_DESCRIPTION = 5000;
+
     /**
      * @return string|null Error message if too long, null if valid.
      */

--- a/tests/InputLengthLimitTest.php
+++ b/tests/InputLengthLimitTest.php
@@ -6,55 +6,63 @@ use PHPUnit\Framework\TestCase;
 
 final class InputLengthLimitTest extends TestCase
 {
+    public function testConstantsExistWithExpectedValues(): void
+    {
+        $this->assertSame(500, InputValidator::MAX_SHIPPING_ADDRESS);
+        $this->assertSame(1000, InputValidator::MAX_INTEREST_MESSAGE);
+        $this->assertSame(255, InputValidator::MAX_PAINTING_TITLE);
+        $this->assertSame(5000, InputValidator::MAX_PAINTING_DESCRIPTION);
+    }
+
     public function testShippingAddressOver500CharsIsRejected(): void
     {
-        $value = str_repeat('a', 501);
-        $error = InputValidator::validateLength($value, 500, 'Shipping address');
+        $value = str_repeat('a', InputValidator::MAX_SHIPPING_ADDRESS + 1);
+        $error = InputValidator::validateLength($value, InputValidator::MAX_SHIPPING_ADDRESS, 'Shipping address');
         $this->assertNotNull($error);
-        $this->assertStringContainsString('500', $error);
+        $this->assertStringContainsString((string) InputValidator::MAX_SHIPPING_ADDRESS, $error);
         $this->assertStringContainsString('Shipping address', $error);
     }
 
     public function testShippingAddressAtExactly500CharsIsAccepted(): void
     {
-        $value = str_repeat('a', 500);
-        $error = InputValidator::validateLength($value, 500, 'Shipping address');
+        $value = str_repeat('a', InputValidator::MAX_SHIPPING_ADDRESS);
+        $error = InputValidator::validateLength($value, InputValidator::MAX_SHIPPING_ADDRESS, 'Shipping address');
         $this->assertNull($error);
     }
 
     public function testInterestMessageOver1000CharsIsRejected(): void
     {
-        $value = str_repeat('b', 1001);
-        $error = InputValidator::validateLength($value, 1000, 'Interest message');
+        $value = str_repeat('b', InputValidator::MAX_INTEREST_MESSAGE + 1);
+        $error = InputValidator::validateLength($value, InputValidator::MAX_INTEREST_MESSAGE, 'Interest message');
         $this->assertNotNull($error);
-        $this->assertStringContainsString('1000', $error);
+        $this->assertStringContainsString((string) InputValidator::MAX_INTEREST_MESSAGE, $error);
     }
 
     public function testPaintingTitleOver255CharsIsRejected(): void
     {
-        $value = str_repeat('c', 256);
-        $error = InputValidator::validateLength($value, 255, 'Title');
+        $value = str_repeat('c', InputValidator::MAX_PAINTING_TITLE + 1);
+        $error = InputValidator::validateLength($value, InputValidator::MAX_PAINTING_TITLE, 'Title');
         $this->assertNotNull($error);
-        $this->assertStringContainsString('255', $error);
+        $this->assertStringContainsString((string) InputValidator::MAX_PAINTING_TITLE, $error);
     }
 
     public function testPaintingDescriptionOver5000CharsIsRejected(): void
     {
-        $value = str_repeat('d', 5001);
-        $error = InputValidator::validateLength($value, 5000, 'Description');
+        $value = str_repeat('d', InputValidator::MAX_PAINTING_DESCRIPTION + 1);
+        $error = InputValidator::validateLength($value, InputValidator::MAX_PAINTING_DESCRIPTION, 'Description');
         $this->assertNotNull($error);
-        $this->assertStringContainsString('5000', $error);
+        $this->assertStringContainsString((string) InputValidator::MAX_PAINTING_DESCRIPTION, $error);
     }
 
     public function testEmptyStringIsAccepted(): void
     {
-        $error = InputValidator::validateLength('', 500, 'Shipping address');
+        $error = InputValidator::validateLength('', InputValidator::MAX_SHIPPING_ADDRESS, 'Shipping address');
         $this->assertNull($error);
     }
 
     public function testStringUnderLimitIsAccepted(): void
     {
-        $error = InputValidator::validateLength('hello', 500, 'Shipping address');
+        $error = InputValidator::validateLength('hello', InputValidator::MAX_SHIPPING_ADDRESS, 'Shipping address');
         $this->assertNull($error);
     }
 }


### PR DESCRIPTION
## Summary
- Adds named constants (`MAX_SHIPPING_ADDRESS`, `MAX_INTEREST_MESSAGE`, `MAX_PAINTING_TITLE`, `MAX_PAINTING_DESCRIPTION`) to `InputValidator`
- Updates all controller call sites to use constants instead of magic numbers
- Updates tests to reference constants, plus a new test verifying constant values

## Test plan
- [x] InputLengthLimitTest passes (8 tests, 16 assertions)
- [x] Full test suite passes (336 tests, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)