### PR TITLE
Extract flash-and-redirect helper to reduce DRY violations (closes #83)

### DIFF
--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -16,6 +16,8 @@ use Heirloom\Thumbnail;
  */
 class AdminController
 {
+    use FlashRedirect;
+
     public function __construct(private Database $db, private Auth $auth, private SiteSettings $settings) {}
 
     public function dashboard(): void
@@ -113,9 +115,7 @@ class AdminController
         // Detect when PHP rejected the POST body as too large
         if (empty($_POST) && empty($_FILES) && isset($_SERVER['CONTENT_LENGTH']) && (int) $_SERVER['CONTENT_LENGTH'] > 0) {
             $maxPost = ini_get('post_max_size');
-            $_SESSION['upload_error'] = "Upload too large. The server limit is {$maxPost}. Try fewer files at once, or ask the admin to increase post_max_size/upload_max_filesize.";
-            header('Location: /admin/upload');
-            exit;
+            $this->redirectWithFlash('/admin/upload', 'upload_error', "Upload too large. The server limit is {$maxPost}. Try fewer files at once, or ask the admin to increase post_max_size/upload_max_filesize.");
         }
 
         $title = trim($_POST['title'] ?? '');
@@ -124,15 +124,11 @@ class AdminController
         $titleError = InputValidator::validateLength($title, 255, 'Title');
         $descError = InputValidator::validateLength($description, 5000, 'Description');
         if ($titleError || $descError) {
-            $_SESSION['upload_error'] = $titleError ?? $descError;
-            header('Location: /admin/upload');
-            exit;
+            $this->redirectWithFlash('/admin/upload', 'upload_error', $titleError ?? $descError);
         }
 
         if (empty($_FILES['paintings']) || !is_array($_FILES['paintings']['name'])) {
-            $_SESSION['upload_error'] = 'Please select at least one image.';
-            header('Location: /admin/upload');
-            exit;
+            $this->redirectWithFlash('/admin/upload', 'upload_error', 'Please select at least one image.');
         }
 
         $uploadDir = dirname(__DIR__, 2) . '/public/uploads/';
@@ -144,9 +140,7 @@ class AdminController
 
         // Single file with no title is an error
         if ($fileCount === 1 && $title === '') {
-            $_SESSION['upload_error'] = 'Title is required for single file uploads.';
-            header('Location: /admin/upload');
-            exit;
+            $this->redirectWithFlash('/admin/upload', 'upload_error', 'Title is required for single file uploads.');
         }
 
         for ($i = 0; $i < $fileCount; $i++) {
@@ -196,13 +190,11 @@ class AdminController
         }
 
         if ($uploaded > 0) {
-            $_SESSION['upload_success'] = "$uploaded painting(s) uploaded successfully." .
-                ($errors ? ' Errors: ' . implode(', ', $errors) : '');
+            $this->redirectWithFlash('/admin/upload', 'upload_success', "$uploaded painting(s) uploaded successfully." .
+                ($errors ? ' Errors: ' . implode(', ', $errors) : ''));
         } else {
-            $_SESSION['upload_error'] = 'No paintings uploaded. ' . implode(', ', $errors);
+            $this->redirectWithFlash('/admin/upload', 'upload_error', 'No paintings uploaded. ' . implode(', ', $errors));
         }
-        header('Location: /admin/upload');
-        exit;
     }
 
     public function managePainting(string $id): void
@@ -265,17 +257,13 @@ class AdminController
         $description = trim($_POST['description'] ?? '');
 
         if ($title === '') {
-            $_SESSION['admin_error'] = 'Title cannot be empty.';
-            header('Location: /admin/painting/' . $id);
-            exit;
+            $this->redirectWithFlash('/admin/painting/' . $id, 'admin_error', 'Title cannot be empty.');
         }
 
         $titleError = InputValidator::validateLength($title, 255, 'Title');
         $descError = InputValidator::validateLength($description, 5000, 'Description');
         if ($titleError || $descError) {
-            $_SESSION['admin_error'] = $titleError ?? $descError;
-            header('Location: /admin/painting/' . $id);
-            exit;
+            $this->redirectWithFlash('/admin/painting/' . $id, 'admin_error', $titleError ?? $descError);
         }
 
         $this->db->execute(
@@ -283,9 +271,7 @@ class AdminController
             [':title' => $title, ':desc' => $description, ':id' => (int) $id]
         );
 
-        $_SESSION['admin_success'] = 'Painting updated.';
-        header('Location: /admin/painting/' . $id);
-        exit;
+        $this->redirectWithFlash('/admin/painting/' . $id, 'admin_success', 'Painting updated.');
     }
 
     public function award(string $id): void
@@ -327,7 +313,7 @@ class AdminController
                 $this->auth->sendLoserNotifications($loserEmails, $painting['title']);
             }
 
-            $_SESSION['admin_success'] = 'Painting awarded!';
+            $this->setFlash('admin_success', 'Painting awarded!');
         } else {
             $painting = $this->db->fetchOne('SELECT awarded_to FROM paintings WHERE id = :id', [':id' => (int) $id]);
             if ($painting && $painting['awarded_to']) {
@@ -340,7 +326,7 @@ class AdminController
                 'UPDATE paintings SET awarded_to = NULL, awarded_at = NULL, tracking_number = NULL WHERE id = :id',
                 [':id' => (int) $id]
             );
-            $_SESSION['admin_success'] = 'Painting unassigned.';
+            $this->setFlash('admin_success', 'Painting unassigned.');
         }
 
         header('Location: /admin/painting/' . $id);
@@ -357,9 +343,7 @@ class AdminController
             [':tn' => $tracking !== '' ? $tracking : null, ':id' => (int) $id]
         );
 
-        $_SESSION['admin_success'] = 'Tracking number updated.';
-        header('Location: /admin/painting/' . $id);
-        exit;
+        $this->redirectWithFlash('/admin/painting/' . $id, 'admin_success', 'Tracking number updated.');
     }
 
     public function delete(string $id): void
@@ -539,14 +523,11 @@ class AdminController
             if ($valid) {
                 $this->settings->setBulk($valid);
             }
-            $_SESSION['admin_error'] = implode(' ', array_values($errors));
+            $this->redirectWithFlash('/admin/settings', 'admin_error', implode(' ', array_values($errors)));
         } else {
             $this->settings->setBulk($updates);
-            $_SESSION['admin_success'] = 'Settings saved.';
+            $this->redirectWithFlash('/admin/settings', 'admin_success', 'Settings saved.');
         }
-
-        header('Location: /admin/settings');
-        exit;
     }
 
     /**
@@ -613,20 +594,16 @@ class AdminController
         $name = trim($_POST['name'] ?? '');
 
         if (!$email || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            $_SESSION['admin_error'] = 'Valid email is required.';
-            header('Location: /admin/invite');
-            exit;
+            $this->redirectWithFlash('/admin/invite', 'admin_error', 'Valid email is required.');
         }
 
         $token = $this->auth->createInvite($email, $name);
         $sent = $this->auth->sendInvite($email, $token);
 
         if ($sent) {
-            $_SESSION['admin_success'] = "Invitation sent to $email.";
+            $this->redirectWithFlash('/admin/invite', 'admin_success', "Invitation sent to $email.");
         } else {
-            $_SESSION['admin_error'] = "Invite created but failed to send email to $email. Check mail configuration.";
+            $this->redirectWithFlash('/admin/invite', 'admin_error', "Invite created but failed to send email to $email. Check mail configuration.");
         }
-        header('Location: /admin/invite');
-        exit;
     }
 }

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -18,6 +18,8 @@ use League\OAuth2\Client\Provider\Google;
  */
 class AuthController
 {
+    use FlashRedirect;
+
     private RateLimiter $rateLimiter;
 
     public function __construct(private Database $db, private Auth $auth, private SiteSettings $settings)
@@ -45,17 +47,13 @@ class AuthController
         $password = $_POST['password'] ?? '';
 
         if (!$email) {
-            $_SESSION['auth_error'] = 'Email is required.';
-            header('Location: /login');
-            exit;
+            $this->redirectWithFlash('/login', 'auth_error', 'Email is required.');
         }
 
         $identifier = Auth::normalizeEmail($email);
         if (!$this->rateLimiter->isAllowed($identifier)) {
             $remaining = $this->rateLimiter->remainingAttempts($identifier);
-            $_SESSION['auth_error'] = 'Too many login attempts. Please try again in 15 minutes.';
-            header('Location: /login');
-            exit;
+            $this->redirectWithFlash('/login', 'auth_error', 'Too many login attempts. Please try again in 15 minutes.');
         }
 
         if ($password !== '') {
@@ -67,9 +65,7 @@ class AuthController
                 exit;
             }
             $this->rateLimiter->record($identifier);
-            $_SESSION['auth_error'] = 'Invalid email or password.';
-            header('Location: /login');
-            exit;
+            $this->redirectWithFlash('/login', 'auth_error', 'Invalid email or password.');
         }
 
         // If the user explicitly requested "forgot password", set a session flag
@@ -83,12 +79,10 @@ class AuthController
         $sent = $this->auth->sendMagicLink($email, $token);
 
         if ($sent) {
-            $_SESSION['auth_success'] = 'Check your email for a login link! (Expires in 1 hour)';
+            $this->redirectWithFlash('/login', 'auth_success', 'Check your email for a login link! (Expires in 1 hour)');
         } else {
-            $_SESSION['auth_error'] = 'Failed to send login link. Please try again.';
+            $this->redirectWithFlash('/login', 'auth_error', 'Failed to send login link. Please try again.');
         }
-        header('Location: /login');
-        exit;
     }
 
     public function registerForm(): void
@@ -116,29 +110,21 @@ class AuthController
     public function register(): void
     {
         if (!$this->settings->getBool('registration_open', true)) {
-            $_SESSION['auth_error'] = 'Registration is currently closed.';
-            header('Location: /login');
-            exit;
+            $this->redirectWithFlash('/login', 'auth_error', 'Registration is currently closed.');
         }
         $email = Auth::normalizeEmail($_POST['email'] ?? '');
         $name = trim($_POST['name'] ?? '');
 
         if (!$email || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            $_SESSION['auth_error'] = 'Valid email is required.';
-            header('Location: /register');
-            exit;
+            $this->redirectWithFlash('/register', 'auth_error', 'Valid email is required.');
         }
 
         if (!$this->rateLimiter->isAllowed($email)) {
-            $_SESSION['auth_error'] = 'Too many attempts. Please try again in 15 minutes.';
-            header('Location: /register');
-            exit;
+            $this->redirectWithFlash('/register', 'auth_error', 'Too many attempts. Please try again in 15 minutes.');
         }
 
         if (!$name) {
-            $_SESSION['auth_error'] = 'Name is required.';
-            header('Location: /register');
-            exit;
+            $this->redirectWithFlash('/register', 'auth_error', 'Name is required.');
         }
 
         $this->auth->findOrCreateUserByEmail($email, $name);
@@ -148,21 +134,17 @@ class AuthController
         $sent = $this->auth->sendMagicLink($email, $token);
 
         if ($sent) {
-            $_SESSION['auth_success'] = 'Check your email for a login link!';
+            $this->redirectWithFlash('/login', 'auth_success', 'Check your email for a login link!');
         } else {
-            $_SESSION['auth_error'] = 'Account created but failed to send login link.';
+            $this->redirectWithFlash('/login', 'auth_error', 'Account created but failed to send login link.');
         }
-        header('Location: /login');
-        exit;
     }
 
     public function magicLogin(string $token): void
     {
         $email = $this->auth->consumeMagicLink($token);
         if (!$email) {
-            $_SESSION['auth_error'] = 'Invalid or expired login link.';
-            header('Location: /login');
-            exit;
+            $this->redirectWithFlash('/login', 'auth_error', 'Invalid or expired login link.');
         }
 
         $user = $this->auth->findOrCreateUserByEmail($email);
@@ -220,9 +202,7 @@ class AuthController
 
         $identifier = 'password_change_' . $this->auth->userId();
         if (!$this->rateLimiter->isAllowed($identifier)) {
-            $_SESSION['auth_error'] = 'Too many attempts. Please try again in 15 minutes.';
-            header('Location: /set-password');
-            exit;
+            $this->redirectWithFlash('/set-password', 'auth_error', 'Too many attempts. Please try again in 15 minutes.');
         }
         $this->rateLimiter->record($identifier);
 
@@ -231,14 +211,10 @@ class AuthController
 
         $validationError = self::validatePassword($password);
         if ($validationError !== null) {
-            $_SESSION['auth_error'] = $validationError;
-            header('Location: /set-password');
-            exit;
+            $this->redirectWithFlash('/set-password', 'auth_error', $validationError);
         }
         if ($password !== $confirm) {
-            $_SESSION['auth_error'] = 'Passwords do not match.';
-            header('Location: /set-password');
-            exit;
+            $this->redirectWithFlash('/set-password', 'auth_error', 'Passwords do not match.');
         }
 
         $hash = password_hash($password, PASSWORD_DEFAULT);
@@ -247,9 +223,7 @@ class AuthController
             [':hash' => $hash, ':id' => $this->auth->userId()]
         );
 
-        $_SESSION['auth_success'] = 'Password set successfully!';
-        header('Location: /');
-        exit;
+        $this->redirectWithFlash('/', 'auth_success', 'Password set successfully!');
     }
 
     public function profileForm(): void
@@ -277,9 +251,7 @@ class AuthController
 
         $lengthError = InputValidator::validateLength($address, 500, 'Shipping address');
         if ($lengthError) {
-            $_SESSION['auth_error'] = $lengthError;
-            header('Location: /profile');
-            exit;
+            $this->redirectWithFlash('/profile', 'auth_error', $lengthError);
         }
 
         $this->db->execute(
@@ -287,9 +259,7 @@ class AuthController
             [':addr' => $address !== '' ? $address : null, ':id' => $this->auth->userId()]
         );
 
-        $_SESSION['auth_success'] = 'Shipping address updated.';
-        header('Location: /profile');
-        exit;
+        $this->redirectWithFlash('/profile', 'auth_success', 'Shipping address updated.');
     }
 
     public function googleRedirect(): void
@@ -307,9 +277,7 @@ class AuthController
 
         if (empty($_GET['state']) || ($_GET['state'] !== ($_SESSION['oauth2state'] ?? ''))) {
             unset($_SESSION['oauth2state']);
-            $_SESSION['auth_error'] = 'Invalid OAuth state.';
-            header('Location: /login');
-            exit;
+            $this->redirectWithFlash('/login', 'auth_error', 'Invalid OAuth state.');
         }
 
         try {
@@ -319,9 +287,7 @@ class AuthController
 
             $user = $this->auth->findUserByEmail($email);
             if (!$user) {
-                $_SESSION['auth_error'] = 'No account found for that Google email. Please register first.';
-                header('Location: /register');
-                exit;
+                $this->redirectWithFlash('/register', 'auth_error', 'No account found for that Google email. Please register first.');
             }
 
             $this->auth->loginUser((int) $user['id']);
@@ -329,9 +295,7 @@ class AuthController
             exit;
         } catch (\Exception $e) {
             error_log('OAuth error: ' . $e->getMessage());
-            $_SESSION['auth_error'] = 'Google login failed. Please try again.';
-            header('Location: /login');
-            exit;
+            $this->redirectWithFlash('/login', 'auth_error', 'Google login failed. Please try again.');
         }
     }
 

--- a/src/Controllers/FlashRedirect.php
+++ b/src/Controllers/FlashRedirect.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Controllers;
+
+/**
+ * Trait providing a flash-and-redirect helper to eliminate repeated
+ * $_SESSION + header('Location:') + exit patterns across controllers.
+ */
+trait FlashRedirect
+{
+    /**
+     * Set a flash message in the session.
+     *
+     * Extracted as a separate method so it can be tested without triggering
+     * header() + exit.
+     */
+    protected function setFlash(string $key, string $message): void
+    {
+        $_SESSION[$key] = $message;
+    }
+
+    /**
+     * Set a flash message and redirect to the given URL.
+     *
+     * @return never
+     */
+    protected function redirectWithFlash(string $url, string $key, string $message): never
+    {
+        $this->setFlash($key, $message);
+        header('Location: ' . $url);
+        exit;
+    }
+}

--- a/src/Controllers/GalleryController.php
+++ b/src/Controllers/GalleryController.php
@@ -16,6 +16,8 @@ use Heirloom\Template;
  */
 class GalleryController
 {
+    use FlashRedirect;
+
     public function __construct(private Database $db, private Auth $auth, private SiteSettings $settings) {}
 
     public function index(): void
@@ -149,9 +151,7 @@ class GalleryController
 
         $lengthError = InputValidator::validateLength($message, 1000, 'Interest message');
         if ($lengthError) {
-            $_SESSION['gallery_error'] = $lengthError;
-            header('Location: /painting/' . $id);
-            exit;
+            $this->redirectWithFlash('/painting/' . $id, 'gallery_error', $lengthError);
         }
 
         if ($existing) {

--- a/tests/FlashRedirectTest.php
+++ b/tests/FlashRedirectTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Controllers\FlashRedirect;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the FlashRedirect trait's session-setting helper.
+ *
+ * Since redirectWithFlash() calls header() + exit (returning `never`),
+ * we test the extracted setFlash() method directly, verifying that it
+ * correctly sets the session key/value pair.
+ */
+class FlashRedirectTest extends TestCase
+{
+    private object $controller;
+
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+        $_SESSION = [];
+
+        // Anonymous class that uses the trait so we can test it
+        $this->controller = new class {
+            use FlashRedirect;
+
+            // Expose the protected method for testing
+            public function testSetFlash(string $key, string $message): void
+            {
+                $this->setFlash($key, $message);
+            }
+        };
+    }
+
+    public function testSetFlashSetsSessionValue(): void
+    {
+        $this->controller->testSetFlash('admin_error', 'Something went wrong.');
+
+        $this->assertSame('Something went wrong.', $_SESSION['admin_error']);
+    }
+
+    public function testSetFlashOverwritesPreviousValue(): void
+    {
+        $_SESSION['auth_error'] = 'Old message';
+
+        $this->controller->testSetFlash('auth_error', 'New message');
+
+        $this->assertSame('New message', $_SESSION['auth_error']);
+    }
+
+    public function testSetFlashWorksWithDifferentKeys(): void
+    {
+        $this->controller->testSetFlash('upload_success', 'Upload complete.');
+        $this->controller->testSetFlash('admin_error', 'Validation failed.');
+
+        $this->assertSame('Upload complete.', $_SESSION['upload_success']);
+        $this->assertSame('Validation failed.', $_SESSION['admin_error']);
+    }
+
+    public function testSetFlashWithEmptyMessage(): void
+    {
+        $this->controller->testSetFlash('auth_error', '');
+
+        $this->assertSame('', $_SESSION['auth_error']);
+    }
+
+    public function testSetFlashDoesNotAffectOtherSessionKeys(): void
+    {
+        $_SESSION['existing_key'] = 'untouched';
+
+        $this->controller->testSetFlash('admin_success', 'Done.');
+
+        $this->assertSame('untouched', $_SESSION['existing_key']);
+        $this->assertSame('Done.', $_SESSION['admin_success']);
+    }
+}


### PR DESCRIPTION
Extracted a FlashRedirect trait with setFlash() and redirectWithFlash() helpers, replacing ~30 repeated instances of the session-set/header/exit pattern across AdminController, AuthController, and GalleryController. Includes 5 new unit tests. All 340 existing tests pass with no regressions.