### PR TITLE
Extract route, flash key, and error message constants

### DIFF
--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -102,10 +102,10 @@ class AdminController
         $this->auth->requireAdmin();
         Template::render('admin/upload', [
             'auth' => $this->auth,
-            'error' => $_SESSION['upload_error'] ?? null,
-            'success' => $_SESSION['upload_success'] ?? null,
+            'error' => $_SESSION[Flash::UPLOAD_ERROR] ?? null,
+            'success' => $_SESSION[Flash::UPLOAD_SUCCESS] ?? null,
         ]);
-        unset($_SESSION['upload_error'], $_SESSION['upload_success']);
+        unset($_SESSION[Flash::UPLOAD_ERROR], $_SESSION[Flash::UPLOAD_SUCCESS]);
     }
 
     public function upload(): void
@@ -115,7 +115,7 @@ class AdminController
         // Detect when PHP rejected the POST body as too large
         if (empty($_POST) && empty($_FILES) && isset($_SERVER['CONTENT_LENGTH']) && (int) $_SERVER['CONTENT_LENGTH'] > 0) {
             $maxPost = ini_get('post_max_size');
-            $this->redirectWithFlash('/admin/upload', 'upload_error', "Upload too large. The server limit is {$maxPost}. Try fewer files at once, or ask the admin to increase post_max_size/upload_max_filesize.");
+            $this->redirectWithFlash(Routes::ADMIN_UPLOAD, Flash::UPLOAD_ERROR, "Upload too large. The server limit is {$maxPost}. Try fewer files at once, or ask the admin to increase post_max_size/upload_max_filesize.");
         }
 
         $title = trim($_POST['title'] ?? '');
@@ -124,11 +124,11 @@ class AdminController
         $titleError = InputValidator::validateLength($title, 255, 'Title');
         $descError = InputValidator::validateLength($description, 5000, 'Description');
         if ($titleError || $descError) {
-            $this->redirectWithFlash('/admin/upload', 'upload_error', $titleError ?? $descError);
+            $this->redirectWithFlash(Routes::ADMIN_UPLOAD, Flash::UPLOAD_ERROR, $titleError ?? $descError);
         }
 
         if (empty($_FILES['paintings']) || !is_array($_FILES['paintings']['name'])) {
-            $this->redirectWithFlash('/admin/upload', 'upload_error', 'Please select at least one image.');
+            $this->redirectWithFlash(Routes::ADMIN_UPLOAD, Flash::UPLOAD_ERROR, 'Please select at least one image.');
         }
 
         $uploadDir = dirname(__DIR__, 2) . '/public/uploads/';
@@ -140,7 +140,7 @@ class AdminController
 
         // Single file with no title is an error
         if ($fileCount === 1 && $title === '') {
-            $this->redirectWithFlash('/admin/upload', 'upload_error', 'Title is required for single file uploads.');
+            $this->redirectWithFlash(Routes::ADMIN_UPLOAD, Flash::UPLOAD_ERROR, 'Title is required for single file uploads.');
         }
 
         for ($i = 0; $i < $fileCount; $i++) {
@@ -190,10 +190,10 @@ class AdminController
         }
 
         if ($uploaded > 0) {
-            $this->redirectWithFlash('/admin/upload', 'upload_success', "$uploaded painting(s) uploaded successfully." .
+            $this->redirectWithFlash(Routes::ADMIN_UPLOAD, Flash::UPLOAD_SUCCESS, "$uploaded painting(s) uploaded successfully." .
                 ($errors ? ' Errors: ' . implode(', ', $errors) : ''));
         } else {
-            $this->redirectWithFlash('/admin/upload', 'upload_error', 'No paintings uploaded. ' . implode(', ', $errors));
+            $this->redirectWithFlash(Routes::ADMIN_UPLOAD, Flash::UPLOAD_ERROR, 'No paintings uploaded. ' . implode(', ', $errors));
         }
     }
 
@@ -243,10 +243,10 @@ class AdminController
             'awardedUser' => $awardedUser,
             'awardLog' => $awardLog,
             'auth' => $this->auth,
-            'success' => $_SESSION['admin_success'] ?? null,
-            'error' => $_SESSION['admin_error'] ?? null,
+            'success' => $_SESSION[Flash::ADMIN_SUCCESS] ?? null,
+            'error' => $_SESSION[Flash::ADMIN_ERROR] ?? null,
         ]);
-        unset($_SESSION['admin_success'], $_SESSION['admin_error']);
+        unset($_SESSION[Flash::ADMIN_SUCCESS], $_SESSION[Flash::ADMIN_ERROR]);
     }
 
     public function edit(string $id): void
@@ -257,13 +257,13 @@ class AdminController
         $description = trim($_POST['description'] ?? '');
 
         if ($title === '') {
-            $this->redirectWithFlash('/admin/painting/' . $id, 'admin_error', 'Title cannot be empty.');
+            $this->redirectWithFlash(Routes::adminPainting($id), Flash::ADMIN_ERROR, 'Title cannot be empty.');
         }
 
         $titleError = InputValidator::validateLength($title, 255, 'Title');
         $descError = InputValidator::validateLength($description, 5000, 'Description');
         if ($titleError || $descError) {
-            $this->redirectWithFlash('/admin/painting/' . $id, 'admin_error', $titleError ?? $descError);
+            $this->redirectWithFlash(Routes::adminPainting($id), Flash::ADMIN_ERROR, $titleError ?? $descError);
         }
 
         $this->db->execute(
@@ -271,7 +271,7 @@ class AdminController
             [':title' => $title, ':desc' => $description, ':id' => (int) $id]
         );
 
-        $this->redirectWithFlash('/admin/painting/' . $id, 'admin_success', 'Painting updated.');
+        $this->redirectWithFlash(Routes::adminPainting($id), Flash::ADMIN_SUCCESS, 'Painting updated.');
     }
 
     public function award(string $id): void
@@ -313,7 +313,7 @@ class AdminController
                 $this->auth->sendLoserNotifications($loserEmails, $painting['title']);
             }
 
-            $this->setFlash('admin_success', 'Painting awarded!');
+            $this->setFlash(Flash::ADMIN_SUCCESS, 'Painting awarded!');
         } else {
             $painting = $this->db->fetchOne('SELECT awarded_to FROM paintings WHERE id = :id', [':id' => (int) $id]);
             if ($painting && $painting['awarded_to']) {
@@ -326,10 +326,10 @@ class AdminController
                 'UPDATE paintings SET awarded_to = NULL, awarded_at = NULL, tracking_number = NULL WHERE id = :id',
                 [':id' => (int) $id]
             );
-            $this->setFlash('admin_success', 'Painting unassigned.');
+            $this->setFlash(Flash::ADMIN_SUCCESS, 'Painting unassigned.');
         }
 
-        header('Location: /admin/painting/' . $id);
+        header('Location: ' . Routes::adminPainting($id));
         exit;
     }
 
@@ -343,7 +343,7 @@ class AdminController
             [':tn' => $tracking !== '' ? $tracking : null, ':id' => (int) $id]
         );
 
-        $this->redirectWithFlash('/admin/painting/' . $id, 'admin_success', 'Tracking number updated.');
+        $this->redirectWithFlash(Routes::adminPainting($id), Flash::ADMIN_SUCCESS, 'Tracking number updated.');
     }
 
     public function delete(string $id): void
@@ -362,7 +362,7 @@ class AdminController
             $this->db->execute('DELETE FROM paintings WHERE id = :id', [':id' => (int) $id]);
         }
 
-        header('Location: /admin');
+        header('Location: ' . Routes::ADMIN);
         exit;
     }
 
@@ -496,10 +496,10 @@ class AdminController
         Template::render('admin/settings', [
             'settings' => $allSettings,
             'auth' => $this->auth,
-            'success' => $_SESSION['admin_success'] ?? null,
-            'error' => $_SESSION['admin_error'] ?? null,
+            'success' => $_SESSION[Flash::ADMIN_SUCCESS] ?? null,
+            'error' => $_SESSION[Flash::ADMIN_ERROR] ?? null,
         ]);
-        unset($_SESSION['admin_success'], $_SESSION['admin_error']);
+        unset($_SESSION[Flash::ADMIN_SUCCESS], $_SESSION[Flash::ADMIN_ERROR]);
     }
 
     public function updateSettings(): void
@@ -523,10 +523,10 @@ class AdminController
             if ($valid) {
                 $this->settings->setBulk($valid);
             }
-            $this->redirectWithFlash('/admin/settings', 'admin_error', implode(' ', array_values($errors)));
+            $this->redirectWithFlash(Routes::ADMIN_SETTINGS, Flash::ADMIN_ERROR, implode(' ', array_values($errors)));
         } else {
             $this->settings->setBulk($updates);
-            $this->redirectWithFlash('/admin/settings', 'admin_success', 'Settings saved.');
+            $this->redirectWithFlash(Routes::ADMIN_SETTINGS, Flash::ADMIN_SUCCESS, 'Settings saved.');
         }
     }
 
@@ -580,10 +580,10 @@ class AdminController
         $this->auth->requireAdmin();
         Template::render('admin/invite', [
             'auth' => $this->auth,
-            'success' => $_SESSION['admin_success'] ?? null,
-            'error' => $_SESSION['admin_error'] ?? null,
+            'success' => $_SESSION[Flash::ADMIN_SUCCESS] ?? null,
+            'error' => $_SESSION[Flash::ADMIN_ERROR] ?? null,
         ]);
-        unset($_SESSION['admin_success'], $_SESSION['admin_error']);
+        unset($_SESSION[Flash::ADMIN_SUCCESS], $_SESSION[Flash::ADMIN_ERROR]);
     }
 
     public function invite(): void
@@ -594,16 +594,16 @@ class AdminController
         $name = trim($_POST['name'] ?? '');
 
         if (!$email || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            $this->redirectWithFlash('/admin/invite', 'admin_error', 'Valid email is required.');
+            $this->redirectWithFlash(Routes::ADMIN_INVITE, Flash::ADMIN_ERROR, Flash::MSG_VALID_EMAIL_REQUIRED);
         }
 
         $token = $this->auth->createInvite($email, $name);
         $sent = $this->auth->sendInvite($email, $token);
 
         if ($sent) {
-            $this->redirectWithFlash('/admin/invite', 'admin_success', "Invitation sent to $email.");
+            $this->redirectWithFlash(Routes::ADMIN_INVITE, Flash::ADMIN_SUCCESS, "Invitation sent to $email.");
         } else {
-            $this->redirectWithFlash('/admin/invite', 'admin_error', "Invite created but failed to send email to $email. Check mail configuration.");
+            $this->redirectWithFlash(Routes::ADMIN_INVITE, Flash::ADMIN_ERROR, "Invite created but failed to send email to $email. Check mail configuration.");
         }
     }
 }

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -34,11 +34,11 @@ class AuthController
             exit;
         }
         Template::render('login', [
-            'error' => $_SESSION['auth_error'] ?? null,
-            'success' => $_SESSION['auth_success'] ?? null,
+            'error' => $_SESSION[Flash::AUTH_ERROR] ?? null,
+            'success' => $_SESSION[Flash::AUTH_SUCCESS] ?? null,
             'auth' => $this->auth,
         ]);
-        unset($_SESSION['auth_error'], $_SESSION['auth_success']);
+        unset($_SESSION[Flash::AUTH_ERROR], $_SESSION[Flash::AUTH_SUCCESS]);
     }
 
     public function login(): void
@@ -47,13 +47,13 @@ class AuthController
         $password = $_POST['password'] ?? '';
 
         if (!$email) {
-            $this->redirectWithFlash('/login', 'auth_error', 'Email is required.');
+            $this->redirectWithFlash(Routes::LOGIN, Flash::AUTH_ERROR, 'Email is required.');
         }
 
         $identifier = Auth::normalizeEmail($email);
         if (!$this->rateLimiter->isAllowed($identifier)) {
             $remaining = $this->rateLimiter->remainingAttempts($identifier);
-            $this->redirectWithFlash('/login', 'auth_error', 'Too many login attempts. Please try again in 15 minutes.');
+            $this->redirectWithFlash(Routes::LOGIN, Flash::AUTH_ERROR, 'Too many login attempts. Please try again in 15 minutes.');
         }
 
         if ($password !== '') {
@@ -65,7 +65,7 @@ class AuthController
                 exit;
             }
             $this->rateLimiter->record($identifier);
-            $this->redirectWithFlash('/login', 'auth_error', 'Invalid email or password.');
+            $this->redirectWithFlash(Routes::LOGIN, Flash::AUTH_ERROR, 'Invalid email or password.');
         }
 
         // If the user explicitly requested "forgot password", set a session flag
@@ -79,9 +79,9 @@ class AuthController
         $sent = $this->auth->sendMagicLink($email, $token);
 
         if ($sent) {
-            $this->redirectWithFlash('/login', 'auth_success', 'Check your email for a login link! (Expires in 1 hour)');
+            $this->redirectWithFlash(Routes::LOGIN, Flash::AUTH_SUCCESS, 'Check your email for a login link! (Expires in 1 hour)');
         } else {
-            $this->redirectWithFlash('/login', 'auth_error', 'Failed to send login link. Please try again.');
+            $this->redirectWithFlash(Routes::LOGIN, Flash::AUTH_ERROR, 'Failed to send login link. Please try again.');
         }
     }
 
@@ -100,31 +100,31 @@ class AuthController
             return;
         }
         Template::render('register', [
-            'error' => $_SESSION['auth_error'] ?? null,
+            'error' => $_SESSION[Flash::AUTH_ERROR] ?? null,
             'auth' => $this->auth,
             'closed' => false,
         ]);
-        unset($_SESSION['auth_error']);
+        unset($_SESSION[Flash::AUTH_ERROR]);
     }
 
     public function register(): void
     {
         if (!$this->settings->getBool('registration_open', true)) {
-            $this->redirectWithFlash('/login', 'auth_error', 'Registration is currently closed.');
+            $this->redirectWithFlash(Routes::LOGIN, Flash::AUTH_ERROR, 'Registration is currently closed.');
         }
         $email = Auth::normalizeEmail($_POST['email'] ?? '');
         $name = trim($_POST['name'] ?? '');
 
         if (!$email || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            $this->redirectWithFlash('/register', 'auth_error', 'Valid email is required.');
+            $this->redirectWithFlash(Routes::REGISTER, Flash::AUTH_ERROR, Flash::MSG_VALID_EMAIL_REQUIRED);
         }
 
         if (!$this->rateLimiter->isAllowed($email)) {
-            $this->redirectWithFlash('/register', 'auth_error', 'Too many attempts. Please try again in 15 minutes.');
+            $this->redirectWithFlash(Routes::REGISTER, Flash::AUTH_ERROR, Flash::MSG_TOO_MANY_ATTEMPTS);
         }
 
         if (!$name) {
-            $this->redirectWithFlash('/register', 'auth_error', 'Name is required.');
+            $this->redirectWithFlash(Routes::REGISTER, Flash::AUTH_ERROR, 'Name is required.');
         }
 
         $this->auth->findOrCreateUserByEmail($email, $name);
@@ -134,9 +134,9 @@ class AuthController
         $sent = $this->auth->sendMagicLink($email, $token);
 
         if ($sent) {
-            $this->redirectWithFlash('/login', 'auth_success', 'Check your email for a login link!');
+            $this->redirectWithFlash(Routes::LOGIN, Flash::AUTH_SUCCESS, 'Check your email for a login link!');
         } else {
-            $this->redirectWithFlash('/login', 'auth_error', 'Account created but failed to send login link.');
+            $this->redirectWithFlash(Routes::LOGIN, Flash::AUTH_ERROR, 'Account created but failed to send login link.');
         }
     }
 
@@ -144,7 +144,7 @@ class AuthController
     {
         $email = $this->auth->consumeMagicLink($token);
         if (!$email) {
-            $this->redirectWithFlash('/login', 'auth_error', 'Invalid or expired login link.');
+            $this->redirectWithFlash(Routes::LOGIN, Flash::AUTH_ERROR, 'Invalid or expired login link.');
         }
 
         $user = $this->auth->findOrCreateUserByEmail($email);
@@ -168,10 +168,10 @@ class AuthController
         $this->auth->requireLogin();
         Template::render('set-password', [
             'auth' => $this->auth,
-            'error' => $_SESSION['auth_error'] ?? null,
-            'success' => $_SESSION['auth_success'] ?? null,
+            'error' => $_SESSION[Flash::AUTH_ERROR] ?? null,
+            'success' => $_SESSION[Flash::AUTH_SUCCESS] ?? null,
         ]);
-        unset($_SESSION['auth_error'], $_SESSION['auth_success']);
+        unset($_SESSION[Flash::AUTH_ERROR], $_SESSION[Flash::AUTH_SUCCESS]);
     }
 
     /**
@@ -202,7 +202,7 @@ class AuthController
 
         $identifier = 'password_change_' . $this->auth->userId();
         if (!$this->rateLimiter->isAllowed($identifier)) {
-            $this->redirectWithFlash('/set-password', 'auth_error', 'Too many attempts. Please try again in 15 minutes.');
+            $this->redirectWithFlash(Routes::SET_PASSWORD, Flash::AUTH_ERROR, Flash::MSG_TOO_MANY_ATTEMPTS);
         }
         $this->rateLimiter->record($identifier);
 
@@ -211,10 +211,10 @@ class AuthController
 
         $validationError = self::validatePassword($password);
         if ($validationError !== null) {
-            $this->redirectWithFlash('/set-password', 'auth_error', $validationError);
+            $this->redirectWithFlash(Routes::SET_PASSWORD, Flash::AUTH_ERROR, $validationError);
         }
         if ($password !== $confirm) {
-            $this->redirectWithFlash('/set-password', 'auth_error', 'Passwords do not match.');
+            $this->redirectWithFlash(Routes::SET_PASSWORD, Flash::AUTH_ERROR, 'Passwords do not match.');
         }
 
         $hash = password_hash($password, PASSWORD_DEFAULT);
@@ -223,7 +223,7 @@ class AuthController
             [':hash' => $hash, ':id' => $this->auth->userId()]
         );
 
-        $this->redirectWithFlash('/', 'auth_success', 'Password set successfully!');
+        $this->redirectWithFlash('/', Flash::AUTH_SUCCESS, 'Password set successfully!');
     }
 
     public function profileForm(): void
@@ -238,10 +238,10 @@ class AuthController
             'auth' => $this->auth,
             'user' => $user,
             'awardedPaintings' => $awardedPaintings,
-            'success' => $_SESSION['auth_success'] ?? null,
-            'error' => $_SESSION['auth_error'] ?? null,
+            'success' => $_SESSION[Flash::AUTH_SUCCESS] ?? null,
+            'error' => $_SESSION[Flash::AUTH_ERROR] ?? null,
         ]);
-        unset($_SESSION['auth_success'], $_SESSION['auth_error']);
+        unset($_SESSION[Flash::AUTH_SUCCESS], $_SESSION[Flash::AUTH_ERROR]);
     }
 
     public function updateProfile(): void
@@ -251,7 +251,7 @@ class AuthController
 
         $lengthError = InputValidator::validateLength($address, 500, 'Shipping address');
         if ($lengthError) {
-            $this->redirectWithFlash('/profile', 'auth_error', $lengthError);
+            $this->redirectWithFlash(Routes::PROFILE, Flash::AUTH_ERROR, $lengthError);
         }
 
         $this->db->execute(
@@ -259,7 +259,7 @@ class AuthController
             [':addr' => $address !== '' ? $address : null, ':id' => $this->auth->userId()]
         );
 
-        $this->redirectWithFlash('/profile', 'auth_success', 'Shipping address updated.');
+        $this->redirectWithFlash(Routes::PROFILE, Flash::AUTH_SUCCESS, 'Shipping address updated.');
     }
 
     public function googleRedirect(): void
@@ -277,7 +277,7 @@ class AuthController
 
         if (empty($_GET['state']) || ($_GET['state'] !== ($_SESSION['oauth2state'] ?? ''))) {
             unset($_SESSION['oauth2state']);
-            $this->redirectWithFlash('/login', 'auth_error', 'Invalid OAuth state.');
+            $this->redirectWithFlash(Routes::LOGIN, Flash::AUTH_ERROR, 'Invalid OAuth state.');
         }
 
         try {
@@ -287,7 +287,7 @@ class AuthController
 
             $user = $this->auth->findUserByEmail($email);
             if (!$user) {
-                $this->redirectWithFlash('/register', 'auth_error', 'No account found for that Google email. Please register first.');
+                $this->redirectWithFlash(Routes::REGISTER, Flash::AUTH_ERROR, 'No account found for that Google email. Please register first.');
             }
 
             $this->auth->loginUser((int) $user['id']);
@@ -295,7 +295,7 @@ class AuthController
             exit;
         } catch (\Exception $e) {
             error_log('OAuth error: ' . $e->getMessage());
-            $this->redirectWithFlash('/login', 'auth_error', 'Google login failed. Please try again.');
+            $this->redirectWithFlash(Routes::LOGIN, Flash::AUTH_ERROR, 'Google login failed. Please try again.');
         }
     }
 

--- a/src/Controllers/Flash.php
+++ b/src/Controllers/Flash.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Controllers;
+
+final class Flash
+{
+    public const AUTH_ERROR = 'auth_error';
+    public const AUTH_SUCCESS = 'auth_success';
+    public const ADMIN_ERROR = 'admin_error';
+    public const ADMIN_SUCCESS = 'admin_success';
+    public const UPLOAD_ERROR = 'upload_error';
+    public const UPLOAD_SUCCESS = 'upload_success';
+    public const GALLERY_ERROR = 'gallery_error';
+
+    public const MSG_VALID_EMAIL_REQUIRED = 'Valid email is required.';
+    public const MSG_TOO_MANY_ATTEMPTS = 'Too many attempts. Please try again in 15 minutes.';
+}

--- a/src/Controllers/GalleryController.php
+++ b/src/Controllers/GalleryController.php
@@ -151,7 +151,7 @@ class GalleryController
 
         $lengthError = InputValidator::validateLength($message, 1000, 'Interest message');
         if ($lengthError) {
-            $this->redirectWithFlash('/painting/' . $id, 'gallery_error', $lengthError);
+            $this->redirectWithFlash(Routes::painting($id), Flash::GALLERY_ERROR, $lengthError);
         }
 
         if ($existing) {

--- a/src/Controllers/Routes.php
+++ b/src/Controllers/Routes.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Controllers;
+
+final class Routes
+{
+    public const LOGIN = '/login';
+    public const REGISTER = '/register';
+    public const SET_PASSWORD = '/set-password';
+    public const PROFILE = '/profile';
+    public const ADMIN = '/admin';
+    public const ADMIN_UPLOAD = '/admin/upload';
+    public const ADMIN_SETTINGS = '/admin/settings';
+    public const ADMIN_INVITE = '/admin/invite';
+
+    public static function adminPainting(string $id): string
+    {
+        return '/admin/painting/' . $id;
+    }
+
+    public static function painting(string $id): string
+    {
+        return '/painting/' . $id;
+    }
+}

--- a/tests/ControllerConstantsTest.php
+++ b/tests/ControllerConstantsTest.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\Controllers\Routes;
+use Heirloom\Controllers\Flash;
+use PHPUnit\Framework\TestCase;
+
+class ControllerConstantsTest extends TestCase
+{
+    // --- Route constants ---
+
+    public function testLoginRouteConstant(): void
+    {
+        $this->assertSame('/login', Routes::LOGIN);
+    }
+
+    public function testRegisterRouteConstant(): void
+    {
+        $this->assertSame('/register', Routes::REGISTER);
+    }
+
+    public function testSetPasswordRouteConstant(): void
+    {
+        $this->assertSame('/set-password', Routes::SET_PASSWORD);
+    }
+
+    public function testProfileRouteConstant(): void
+    {
+        $this->assertSame('/profile', Routes::PROFILE);
+    }
+
+    public function testAdminDashboardRouteConstant(): void
+    {
+        $this->assertSame('/admin', Routes::ADMIN);
+    }
+
+    public function testAdminUploadRouteConstant(): void
+    {
+        $this->assertSame('/admin/upload', Routes::ADMIN_UPLOAD);
+    }
+
+    public function testAdminSettingsRouteConstant(): void
+    {
+        $this->assertSame('/admin/settings', Routes::ADMIN_SETTINGS);
+    }
+
+    public function testAdminInviteRouteConstant(): void
+    {
+        $this->assertSame('/admin/invite', Routes::ADMIN_INVITE);
+    }
+
+    public function testAdminPaintingRouteHelper(): void
+    {
+        $this->assertSame('/admin/painting/42', Routes::adminPainting('42'));
+    }
+
+    public function testPaintingRouteHelper(): void
+    {
+        $this->assertSame('/painting/7', Routes::painting('7'));
+    }
+
+    // --- Flash key constants ---
+
+    public function testAuthErrorFlashKey(): void
+    {
+        $this->assertSame('auth_error', Flash::AUTH_ERROR);
+    }
+
+    public function testAuthSuccessFlashKey(): void
+    {
+        $this->assertSame('auth_success', Flash::AUTH_SUCCESS);
+    }
+
+    public function testAdminErrorFlashKey(): void
+    {
+        $this->assertSame('admin_error', Flash::ADMIN_ERROR);
+    }
+
+    public function testAdminSuccessFlashKey(): void
+    {
+        $this->assertSame('admin_success', Flash::ADMIN_SUCCESS);
+    }
+
+    public function testUploadErrorFlashKey(): void
+    {
+        $this->assertSame('upload_error', Flash::UPLOAD_ERROR);
+    }
+
+    public function testUploadSuccessFlashKey(): void
+    {
+        $this->assertSame('upload_success', Flash::UPLOAD_SUCCESS);
+    }
+
+    public function testGalleryErrorFlashKey(): void
+    {
+        $this->assertSame('gallery_error', Flash::GALLERY_ERROR);
+    }
+
+    // --- Shared error message constants ---
+
+    public function testValidEmailRequiredMessage(): void
+    {
+        $this->assertSame('Valid email is required.', Flash::MSG_VALID_EMAIL_REQUIRED);
+    }
+
+    public function testTooManyAttemptsMessage(): void
+    {
+        $this->assertSame('Too many attempts. Please try again in 15 minutes.', Flash::MSG_TOO_MANY_ATTEMPTS);
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to PR #86 (FlashRedirect trait). Extracts repeated string literals into constants:

- **`Routes`** class: URL constants (`LOGIN`, `REGISTER`, `ADMIN_UPLOAD`, etc.) and helper methods (`adminPainting($id)`, `painting($id)`) for dynamic routes
- **`Flash`** class: session key constants (`AUTH_ERROR`, `ADMIN_SUCCESS`, `UPLOAD_ERROR`, etc.) and shared error messages (`MSG_VALID_EMAIL_REQUIRED`, `MSG_TOO_MANY_ATTEMPTS`)
- All raw string literals in `AdminController`, `AuthController`, and `GalleryController` replaced with constants
- Session `$_SESSION['key']` reads in form-rendering methods also updated

## Test plan
- [x] 19 new tests in `ControllerConstantsTest.php` verify all constant values
- [x] Full test suite (359 tests, 569 assertions) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)