### PR TITLE
Fix inconsistent DI: inject RateLimiter into AuthController (closes #97)

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -22,9 +22,13 @@ class AuthController
 
     private RateLimiter $rateLimiter;
 
-    public function __construct(private Database $db, private Auth $auth, private SiteSettings $settings)
-    {
-        $this->rateLimiter = new RateLimiter($db);
+    public function __construct(
+        private Database $db,
+        private Auth $auth,
+        private SiteSettings $settings,
+        ?RateLimiter $rateLimiter = null,
+    ) {
+        $this->rateLimiter = $rateLimiter ?? new RateLimiter($db);
     }
 
     public function loginForm(): void

--- a/tests/Controllers/AuthControllerTest.php
+++ b/tests/Controllers/AuthControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Heirloom\Tests\Controllers;
 
 use Heirloom\Auth;
+use Heirloom\Controllers\AuthController;
 use Heirloom\Database;
 use Heirloom\RateLimiter;
 use Heirloom\SiteSettings;
@@ -315,6 +316,34 @@ class AuthControllerTest extends TestCase
     public function testRegistrationOpenByDefault(): void
     {
         $this->assertTrue($this->settings->getBool('registration_open', true));
+    }
+
+    // ---------------------------------------------------------------
+    // Dependency injection: RateLimiter
+    // ---------------------------------------------------------------
+
+    public function testAuthControllerAcceptsInjectedRateLimiter(): void
+    {
+        $auth = new Auth($this->db);
+        $rateLimiter = new RateLimiter($this->db, 3, 10);
+
+        // The constructor should accept an optional RateLimiter parameter
+        $controller = new AuthController($this->db, $auth, $this->settings, $rateLimiter);
+
+        // Use reflection to verify the injected RateLimiter is used
+        $ref = new \ReflectionProperty($controller, 'rateLimiter');
+        $this->assertSame($rateLimiter, $ref->getValue($controller));
+    }
+
+    public function testAuthControllerCreatesRateLimiterWhenNotInjected(): void
+    {
+        $auth = new Auth($this->db);
+
+        // When no RateLimiter is passed, the constructor should create one
+        $controller = new AuthController($this->db, $auth, $this->settings);
+
+        $ref = new \ReflectionProperty($controller, 'rateLimiter');
+        $this->assertInstanceOf(RateLimiter::class, $ref->getValue($controller));
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- AuthController now accepts an optional `?RateLimiter $rateLimiter` parameter
- Uses `$rateLimiter ?? new RateLimiter($db)` for backward compatibility
- No changes needed at call sites — null default handles existing instantiation

## Test plan
- [x] 2 new tests verify injected and default RateLimiter behavior
- [x] Full test suite (383 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)