### PR TITLE
Add missing unit tests and fix error response consistency (closes #96)

### DIFF
--- a/src/Controllers/AdminController.php
+++ b/src/Controllers/AdminController.php
@@ -207,7 +207,11 @@ class AdminController
         );
         if (!$painting) {
             http_response_code(404);
-            echo '<h1>Painting not found</h1>';
+            Template::render('error', [
+                'code' => 404,
+                'message' => 'Painting not found.',
+                TemplateVar::AUTH => $this->auth,
+            ]);
             return;
         }
 

--- a/src/Controllers/GalleryController.php
+++ b/src/Controllers/GalleryController.php
@@ -100,7 +100,11 @@ class GalleryController
         );
         if (!$painting) {
             http_response_code(404);
-            echo '<h1>Painting not found</h1>';
+            Template::render('error', [
+                'code' => 404,
+                'message' => 'Painting not found.',
+                TemplateVar::AUTH => $this->auth,
+            ]);
             return;
         }
 

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -55,8 +55,7 @@ class Thumbnail
             default => false,
         };
 
-        imagedestroy($source);
-        imagedestroy($thumb);
+        unset($source, $thumb);
 
         return $result;
     }

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -458,7 +458,6 @@ class AuthTest extends TestCase
     {
         // Use reflection to test the private method directly
         $reflection = new \ReflectionMethod(Auth::class, 'magicLinkExpiryMinutes');
-        $reflection->setAccessible(true);
 
         // Without settings, default should be int 60
         $result = $reflection->invoke($this->auth);
@@ -507,7 +506,6 @@ class AuthTest extends TestCase
         $auth->setSettings($settings);
 
         $reflection = new \ReflectionMethod(Auth::class, 'magicLinkExpiryMinutes');
-        $reflection->setAccessible(true);
 
         $result = $reflection->invoke($auth);
         $this->assertIsInt($result);
@@ -520,7 +518,6 @@ class AuthTest extends TestCase
         // The key assertion: magicLinkExpiryMinutes returns int, so the
         // interpolated value in the SQL query is always a safe integer.
         $reflection = new \ReflectionMethod(Auth::class, 'magicLinkExpiryMinutes');
-        $reflection->setAccessible(true);
 
         $result = $reflection->invoke($this->auth);
         // Must be int — this guarantees it's safe for SQL interpolation

--- a/tests/Controllers/Controller404Test.php
+++ b/tests/Controllers/Controller404Test.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests\Controllers;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that controller 404 paths use Template::render('error', ...)
+ * rather than raw echo '<h1>Painting not found</h1>' output.
+ *
+ * These are source-code inspections: we verify the controller source does NOT
+ * contain raw HTML echo for 404 responses, and instead delegates to the error
+ * template for consistent, styled, HTML-escaped error pages.
+ */
+class Controller404Test extends TestCase
+{
+    private function readControllerSource(string $filename): string
+    {
+        $path = __DIR__ . '/../../src/Controllers/' . $filename;
+        $this->assertFileExists($path);
+        return file_get_contents($path);
+    }
+
+    // ---------------------------------------------------------------
+    // GalleryController::show() — must use Template::render for 404
+    // ---------------------------------------------------------------
+
+    public function testGalleryControllerShowDoesNotUseRawEchoFor404(): void
+    {
+        $source = $this->readControllerSource('GalleryController.php');
+
+        $this->assertStringNotContainsString(
+            "echo '<h1>Painting not found</h1>'",
+            $source,
+            'GalleryController::show() should not use raw echo for 404 — use Template::render(\'error\', ...) instead'
+        );
+    }
+
+    public function testGalleryControllerShowUsesErrorTemplate(): void
+    {
+        $source = $this->readControllerSource('GalleryController.php');
+
+        // After the !$painting check, should call Template::render('error', ...)
+        $this->assertStringContainsString(
+            "Template::render('error'",
+            $source,
+            'GalleryController::show() should render the error template for missing paintings'
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // AdminController::managePainting() — must use Template::render for 404
+    // ---------------------------------------------------------------
+
+    public function testAdminControllerManagePaintingDoesNotUseRawEchoFor404(): void
+    {
+        $source = $this->readControllerSource('AdminController.php');
+
+        $this->assertStringNotContainsString(
+            "echo '<h1>Painting not found</h1>'",
+            $source,
+            'AdminController::managePainting() should not use raw echo for 404 — use Template::render(\'error\', ...) instead'
+        );
+    }
+
+    public function testAdminControllerManagePaintingUsesErrorTemplate(): void
+    {
+        $source = $this->readControllerSource('AdminController.php');
+
+        // The managePainting 404 path should use the error template
+        $this->assertStringContainsString(
+            "Template::render('error'",
+            $source,
+            'AdminController::managePainting() should render the error template for missing paintings'
+        );
+    }
+}

--- a/tests/ErrorHandlerFormatTest.php
+++ b/tests/ErrorHandlerFormatTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\ErrorHandler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Additional coverage for ErrorHandler::formatError() beyond ErrorLoggingTest.
+ */
+class ErrorHandlerFormatTest extends TestCase
+{
+    public function testFormatErrorIdIsExactlyEightHexChars(): void
+    {
+        $exception = new \RuntimeException('test');
+        $result = ErrorHandler::formatError($exception);
+
+        // Extract the hex ID between "[Error " and "]"
+        preg_match('/\[Error ([0-9a-f]+)\]/', $result, $matches);
+        $this->assertNotEmpty($matches, 'Error ID should be present in output');
+        $this->assertSame(8, strlen($matches[1]), 'Error ID should be exactly 8 hex characters');
+    }
+
+    public function testFormatErrorGeneratesUniqueIds(): void
+    {
+        $exception = new \RuntimeException('same message');
+        $ids = [];
+        for ($i = 0; $i < 10; $i++) {
+            $result = ErrorHandler::formatError($exception);
+            preg_match('/\[Error ([0-9a-f]{8})\]/', $result, $matches);
+            $ids[] = $matches[1];
+        }
+        // All 10 IDs should be unique (random_bytes guarantees this with overwhelming probability)
+        $this->assertCount(10, array_unique($ids), 'Each call should produce a unique error ID');
+    }
+
+    public function testFormatErrorIncludesExceptionMessage(): void
+    {
+        $msg = 'Connection refused to database server';
+        $exception = new \RuntimeException($msg);
+        $result = ErrorHandler::formatError($exception);
+
+        $this->assertStringContainsString($msg, $result);
+    }
+
+    public function testFormatErrorExcludesFilePath(): void
+    {
+        $exception = new \RuntimeException('oops');
+        $result = ErrorHandler::formatError($exception);
+
+        $this->assertStringNotContainsString(__FILE__, $result);
+        $this->assertStringNotContainsString('.php', $result);
+    }
+
+    public function testFormatErrorExcludesStackTrace(): void
+    {
+        $exception = new \RuntimeException('oops');
+        $result = ErrorHandler::formatError($exception);
+
+        $this->assertStringNotContainsString($exception->getTraceAsString(), $result);
+        $this->assertStringNotContainsString('#0', $result);
+    }
+
+    public function testFormatErrorOutputFormat(): void
+    {
+        $exception = new \RuntimeException('Something broke');
+        $result = ErrorHandler::formatError($exception);
+
+        // Should match: "[Error abcd1234] Something broke"
+        $this->assertMatchesRegularExpression(
+            '/^\[Error [0-9a-f]{8}\] Something broke$/',
+            $result
+        );
+    }
+}

--- a/tests/InputValidatorEdgeCaseTest.php
+++ b/tests/InputValidatorEdgeCaseTest.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+namespace Heirloom\Tests;
+
+use Heirloom\InputValidator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Edge-case tests for InputValidator::validateLength() with multi-byte
+ * UTF-8 strings (emoji, CJK characters) and control characters.
+ *
+ * The implementation uses mb_strlen(), so each multi-byte character should
+ * count as 1 character regardless of byte length.
+ */
+class InputValidatorEdgeCaseTest extends TestCase
+{
+    // ---------------------------------------------------------------
+    // Emoji strings (4 bytes per character in UTF-8)
+    // ---------------------------------------------------------------
+
+    public function testEmojiStringAtExactLimit(): void
+    {
+        // 5 emoji characters, each 4 bytes in UTF-8 but mb_strlen should count 5
+        $value = str_repeat("\u{1F3A8}", 5); // 5 palette emojis
+        $error = InputValidator::validateLength($value, 5, 'Field');
+        $this->assertNull($error, 'Emoji string at exact limit should be accepted');
+    }
+
+    public function testEmojiStringOverLimit(): void
+    {
+        $value = str_repeat("\u{1F3A8}", 6); // 6 palette emojis
+        $error = InputValidator::validateLength($value, 5, 'Field');
+        $this->assertNotNull($error, 'Emoji string over limit should be rejected');
+        $this->assertStringContainsString('5', $error);
+    }
+
+    public function testEmojiStringUnderLimit(): void
+    {
+        $value = str_repeat("\u{1F3A8}", 3); // 3 palette emojis
+        $error = InputValidator::validateLength($value, 5, 'Field');
+        $this->assertNull($error, 'Emoji string under limit should be accepted');
+    }
+
+    // ---------------------------------------------------------------
+    // CJK characters (3 bytes per character in UTF-8)
+    // ---------------------------------------------------------------
+
+    public function testCjkStringAtExactLimit(): void
+    {
+        // Chinese characters, each 3 bytes in UTF-8
+        $value = str_repeat("\u{7F8E}", 10); // 10 copies of character for "beauty"
+        $error = InputValidator::validateLength($value, 10, 'Title');
+        $this->assertNull($error, 'CJK string at exact limit should be accepted');
+    }
+
+    public function testCjkStringOverLimit(): void
+    {
+        $value = str_repeat("\u{7F8E}", 11);
+        $error = InputValidator::validateLength($value, 10, 'Title');
+        $this->assertNotNull($error, 'CJK string over limit should be rejected');
+    }
+
+    public function testMixedAsciiAndCjk(): void
+    {
+        // "Art" (3 chars) + 7 CJK characters = 10 characters total
+        $value = 'Art' . str_repeat("\u{7F8E}", 7);
+        $error = InputValidator::validateLength($value, 10, 'Title');
+        $this->assertNull($error, 'Mixed ASCII+CJK at exact limit should be accepted');
+    }
+
+    public function testMixedAsciiAndCjkOverLimit(): void
+    {
+        // "Art" (3 chars) + 8 CJK characters = 11 characters total
+        $value = 'Art' . str_repeat("\u{7F8E}", 8);
+        $error = InputValidator::validateLength($value, 10, 'Title');
+        $this->assertNotNull($error, 'Mixed ASCII+CJK over limit should be rejected');
+    }
+
+    // ---------------------------------------------------------------
+    // Control characters (single byte, but should still be counted)
+    // ---------------------------------------------------------------
+
+    public function testControlCharactersCountAsCharacters(): void
+    {
+        // 5 tab characters
+        $value = str_repeat("\t", 5);
+        $error = InputValidator::validateLength($value, 5, 'Field');
+        $this->assertNull($error, 'Control characters at exact limit should be accepted');
+    }
+
+    public function testControlCharactersOverLimit(): void
+    {
+        $value = str_repeat("\t", 6);
+        $error = InputValidator::validateLength($value, 5, 'Field');
+        $this->assertNotNull($error, 'Control characters over limit should be rejected');
+    }
+
+    public function testNullBytesCountAsCharacters(): void
+    {
+        $value = str_repeat("\0", 5);
+        $error = InputValidator::validateLength($value, 5, 'Field');
+        $this->assertNull($error, 'Null bytes at exact limit should be accepted');
+    }
+
+    public function testNewlinesCountAsCharacters(): void
+    {
+        $value = str_repeat("\n", 5);
+        $error = InputValidator::validateLength($value, 5, 'Field');
+        $this->assertNull($error, 'Newlines at exact limit should be accepted');
+    }
+
+    public function testMixedEmojiCjkAndAscii(): void
+    {
+        // 1 emoji + 1 CJK + 3 ASCII = 5 characters
+        $value = "\u{1F3A8}\u{7F8E}Art";
+        $this->assertSame(5, mb_strlen($value));
+        $error = InputValidator::validateLength($value, 5, 'Title');
+        $this->assertNull($error, 'Mixed multi-byte string at exact limit should be accepted');
+    }
+
+    public function testMixedEmojiCjkAndAsciiOverLimit(): void
+    {
+        // 1 emoji + 1 CJK + 4 ASCII = 6 characters
+        $value = "\u{1F3A8}\u{7F8E}Arts";
+        $this->assertSame(6, mb_strlen($value));
+        $error = InputValidator::validateLength($value, 5, 'Title');
+        $this->assertNotNull($error, 'Mixed multi-byte string over limit should be rejected');
+    }
+}

--- a/tests/ThumbnailTest.php
+++ b/tests/ThumbnailTest.php
@@ -32,7 +32,7 @@ class ThumbnailTest extends TestCase
 
         $img = imagecreatetruecolor(1200, 800);
         imagejpeg($img, $source);
-        imagedestroy($img);
+        unset($img);
 
         $result = Thumbnail::generateThumbnail($source, $dest, 400);
 
@@ -52,7 +52,7 @@ class ThumbnailTest extends TestCase
         // 1600x800 => aspect ratio 2:1
         $img = imagecreatetruecolor(1600, 800);
         imagejpeg($img, $source);
-        imagedestroy($img);
+        unset($img);
 
         Thumbnail::generateThumbnail($source, $dest, 400);
 
@@ -68,7 +68,7 @@ class ThumbnailTest extends TestCase
 
         $img = imagecreatetruecolor(1000, 500);
         imagepng($img, $source);
-        imagedestroy($img);
+        unset($img);
 
         $result = Thumbnail::generateThumbnail($source, $dest, 400);
 
@@ -88,7 +88,7 @@ class ThumbnailTest extends TestCase
 
         $img = imagecreatetruecolor(800, 600);
         imagejpeg($img, $source);
-        imagedestroy($img);
+        unset($img);
 
         Thumbnail::generateThumbnail($source, $dest, 400);
 
@@ -115,7 +115,7 @@ class ThumbnailTest extends TestCase
 
         $img = imagecreatetruecolor(200, 150);
         imagejpeg($img, $source);
-        imagedestroy($img);
+        unset($img);
 
         Thumbnail::generateThumbnail($source, $dest, 400);
 


### PR DESCRIPTION
## Summary
- **23 new tests** (381 → 404 total) covering ErrorHandler, InputValidator multi-byte edge cases, and controller 404 consistency
- **Fixed 404 error pages** in GalleryController::show() and AdminController::managePainting() — replaced raw `echo` with `Template::render('error', ...)`
- **Eliminated all 10 PHPUnit deprecation warnings**: replaced `imagedestroy()` (deprecated PHP 8.5) with `unset()`, removed no-op `setAccessible()` calls

## Test plan
- [x] 404 total tests, 0 failures, 0 deprecations
- [x] ErrorHandlerFormatTest: 8-char hex ID, message inclusion, file path exclusion
- [x] InputValidatorEdgeCaseTest: emoji, CJK, control chars with mb_strlen
- [x] Controller404Test: both controllers use error template for 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)